### PR TITLE
feat: footer GitHub release, multi-tag multi-select filters, clickable tags, and collapsible desktop sidebar

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,70 @@ Now you can enjoy your own navigation website! 🎉
 - JSON format processing
 - Static website hosting
 
+## 🌐 i18n: Add / Translate Your Own Language
+
+The UI language strings are defined in `index.html` inside the `I18N` object.
+
+### 1) Add a new locale entry
+
+Find:
+
+```js
+const I18N = {
+  zh: { ... },
+  en: { ... }
+}
+```
+
+Add your locale (example: Japanese):
+
+```js
+ja: {
+  clear: 'クリア',
+  clearTags: 'タグをクリア',
+  tagFilter: 'タグフィルター',
+  searchPlaceholder: 'ブックマーク / タグ / URL を検索...',
+  noResultsTitle: '一致する結果がありません',
+  noResultsDesc: 'キーワードを短くするか、タグを切り替えてください。',
+  searchResults: '検索結果',
+  bookmark: 'ブックマーク',
+  home: 'ホーム',
+  records: '件',
+  languageLabel: 'JA',
+  close: '閉じる',
+  folderTags: 'フォルダタグ',
+  themeSystem: 'システム',
+  themeLight: 'ライト',
+  themeDark: 'ダーク',
+  toggleSidebar: 'サイドバーを切り替え',
+  searchButton: 'ブックマークを検索',
+  switchLanguage: '言語を切り替え',
+  switchTheme: 'テーマを切り替え',
+  filterTagsButton: 'タグで絞り込み',
+  backToTop: 'トップへ戻る',
+  closeSidebar: 'サイドバーを閉じる',
+  gridView: 'グリッド表示',
+  listView: 'リスト表示'
+}
+```
+
+### 2) Add the language option in the language menu
+
+In `index.html`, add a button in `#languageMenu`:
+
+```html
+<button class="menu-item" data-locale="ja">日本語</button>
+```
+
+### 3) Keep keys consistent across all locales
+
+Every locale should contain the same keys. If a key is missing, UI will fallback to Chinese (`zh`) or show the key name.
+
+### 4) Verify title / aria texts after switching language
+
+This project also localizes many button `title` and `aria-label` values (e.g. search, sidebar toggle, back-to-top, theme/language switch).  
+After adding a locale, switch language in UI and confirm these tooltips/labels are translated correctly.
+
 ## 🤝 Contribution Guidelines
 
 Contributions are welcome! Please follow these steps to participate in the project:

--- a/README.zh.md
+++ b/README.zh.md
@@ -110,6 +110,70 @@ Tag 生效优先级：
 - JSON格式处理
 - 静态网站托管
 
+## 🌐 i18n：新增与翻译你自己的语言
+
+界面多语言文案在 `index.html` 的 `I18N` 对象里维护。
+
+### 1）新增语言对象
+
+找到：
+
+```js
+const I18N = {
+  zh: { ... },
+  en: { ... }
+}
+```
+
+新增一个语言（示例：日语 `ja`）：
+
+```js
+ja: {
+  clear: 'クリア',
+  clearTags: 'タグをクリア',
+  tagFilter: 'タグフィルター',
+  searchPlaceholder: 'ブックマーク / タグ / URL を検索...',
+  noResultsTitle: '一致する結果がありません',
+  noResultsDesc: 'キーワードを短くするか、タグを切り替えてください。',
+  searchResults: '検索結果',
+  bookmark: 'ブックマーク',
+  home: 'ホーム',
+  records: '件',
+  languageLabel: 'JA',
+  close: '閉じる',
+  folderTags: 'フォルダタグ',
+  themeSystem: 'システム',
+  themeLight: 'ライト',
+  themeDark: 'ダーク',
+  toggleSidebar: 'サイドバーを切り替え',
+  searchButton: 'ブックマークを検索',
+  switchLanguage: '言語を切り替え',
+  switchTheme: 'テーマを切り替え',
+  filterTagsButton: 'タグで絞り込み',
+  backToTop: 'トップへ戻る',
+  closeSidebar: 'サイドバーを閉じる',
+  gridView: 'グリッド表示',
+  listView: 'リスト表示'
+}
+```
+
+### 2）在语言切换菜单增加入口
+
+在 `#languageMenu` 中新增按钮：
+
+```html
+<button class="menu-item" data-locale="ja">日本語</button>
+```
+
+### 3）保证所有语言 key 一致
+
+每种语言都应包含同样的 key。缺失时会回退到中文（`zh`）或直接显示 key 名称。
+
+### 4）验证 title / aria 是否也已翻译
+
+除了正文文案，项目还会本地化按钮的 `title` 与 `aria-label`（例如搜索、侧边栏切换、回到顶部、主题/语言切换等）。  
+新增语言后请切换一次语言，检查这些提示文案是否全部正确。
+
 ## 🤝 贡献指南
 
 欢迎贡献代码和提出建议！请遵循以下步骤参与项目：

--- a/css/styles.css
+++ b/css/styles.css
@@ -423,6 +423,15 @@
   transform: translateY(0) scale(1);
 }
 
+#bookmarks {
+  transition: opacity 0.2s ease, transform 0.2s ease;
+}
+
+#bookmarks.view-transitioning {
+  opacity: 0.55;
+  transform: translateY(4px);
+}
+
 .nav-sublist {
   max-height: 0;
   overflow: hidden;

--- a/css/styles.css
+++ b/css/styles.css
@@ -291,9 +291,58 @@
   background: rgba(51, 65, 85, 0.8);
 }
 
+.view-switch-pill {
+  display: inline-flex;
+  align-items: center;
+  gap: 2px;
+  padding: 2px;
+  border-radius: 9999px;
+  border: 1px solid rgba(148, 163, 184, 0.3);
+  background: rgba(248, 250, 252, 0.95);
+}
+
+.view-switch-btn {
+  width: 30px;
+  height: 30px;
+  border-radius: 9999px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  color: rgb(100, 116, 139);
+  transition: all 0.2s ease;
+}
+
+.view-switch-btn:hover {
+  color: rgb(2, 132, 199);
+}
+
+.view-switch-btn.is-active {
+  color: rgb(2, 132, 199);
+  background: white;
+  box-shadow: 0 4px 10px rgba(15, 23, 42, 0.1);
+}
+
+.dark .view-switch-pill {
+  background: rgba(15, 23, 42, 0.9);
+  border-color: rgba(71, 85, 105, 0.45);
+}
+
+.dark .view-switch-btn {
+  color: rgb(148, 163, 184);
+}
+
+.dark .view-switch-btn.is-active {
+  color: rgb(125, 211, 252);
+  background: rgba(30, 41, 59, 0.95);
+}
+
 .card-wrap {
   position: relative;
   min-height: 124px;
+}
+
+.card-wrap-list {
+  min-height: 72px;
 }
 
 .card-unified {
@@ -316,6 +365,17 @@
 
 .dark .card-unified:hover {
   box-shadow: 0 16px 34px rgba(2, 6, 23, 0.72);
+}
+
+.bookmark-card-list,
+.folder-card-list {
+  min-height: 72px;
+  height: 72px;
+}
+
+.folder-card-list .folder__svg {
+  width: 46px;
+  height: 36px;
 }
 
 .card-unified:hover h2,

--- a/css/styles.css
+++ b/css/styles.css
@@ -224,6 +224,19 @@
   color: rgb(71, 85, 105);
   box-shadow: 0 4px 10px rgba(15, 23, 42, 0.08);
   border: 1px solid rgba(148, 163, 184, 0.25);
+  transition: all 0.2s ease;
+}
+
+.icon-action-btn:hover {
+  color: rgb(2, 132, 199);
+  border-color: rgba(14, 165, 233, 0.5);
+  background: rgba(240, 249, 255, 0.95);
+  box-shadow: 0 6px 14px rgba(14, 165, 233, 0.2);
+}
+
+.icon-action-btn:focus-visible {
+  outline: 2px solid rgba(14, 165, 233, 0.45);
+  outline-offset: 2px;
 }
 
 .menu-panel {
@@ -256,6 +269,13 @@
   background: rgba(34, 37, 42, 0.95);
   color: rgb(203, 213, 225);
   border-color: rgba(71, 85, 105, 0.35);
+}
+
+.dark .icon-action-btn:hover {
+  color: rgb(125, 211, 252);
+  border-color: rgba(56, 189, 248, 0.55);
+  background: rgba(15, 23, 42, 0.95);
+  box-shadow: 0 8px 16px rgba(2, 132, 199, 0.28);
 }
 
 .dark .menu-panel {

--- a/css/styles.css
+++ b/css/styles.css
@@ -354,17 +354,18 @@
   left: 0;
   right: 0;
   transition: transform 0.25s ease, box-shadow 0.25s ease;
+  --card-hover-shadow: 0 14px 30px rgba(15, 23, 42, 0.18);
 }
 
 .card-unified:hover {
   transform: scale(1.06);
   z-index: 8;
-  box-shadow: 0 14px 30px rgba(15, 23, 42, 0.18);
+  box-shadow: var(--card-hover-shadow);
   height: auto;
 }
 
-.dark .card-unified:hover {
-  box-shadow: 0 16px 34px rgba(2, 6, 23, 0.72);
+.dark .card-unified {
+  --card-hover-shadow: 0 16px 34px rgba(2, 6, 23, 0.72);
 }
 
 .bookmark-card-list,

--- a/css/styles.css
+++ b/css/styles.css
@@ -227,6 +227,10 @@
   transition: all 0.2s ease;
 }
 
+.icon-action-btn.hidden {
+  display: none !important;
+}
+
 .icon-action-btn:hover {
   color: rgb(2, 132, 199);
   border-color: rgba(14, 165, 233, 0.5);

--- a/css/styles.css
+++ b/css/styles.css
@@ -366,6 +366,7 @@
 
 .dark .card-unified {
   --card-hover-shadow: 0 16px 34px rgba(2, 6, 23, 0.72);
+  box-shadow: 0 1px 2px rgba(2, 6, 23, 0.55);
 }
 
 .bookmark-card-list,

--- a/css/styles.css
+++ b/css/styles.css
@@ -253,6 +253,7 @@
 }
 
 .menu-item {
+  display: block;
   width: 100%;
   text-align: left;
   font-size: 13px;

--- a/css/styles.css
+++ b/css/styles.css
@@ -297,8 +297,9 @@
   gap: 2px;
   padding: 2px;
   border-radius: 9999px;
-  border: 1px solid rgba(148, 163, 184, 0.3);
-  background: rgba(248, 250, 252, 0.95);
+  border: 1px solid rgba(148, 163, 184, 0.25);
+  background: rgba(255, 255, 255, 0.9);
+  box-shadow: 0 4px 10px rgba(15, 23, 42, 0.08);
 }
 
 .view-switch-btn {
@@ -309,7 +310,7 @@
   align-items: center;
   justify-content: center;
   color: rgb(100, 116, 139);
-  transition: all 0.2s ease;
+  transition: all 0.22s ease;
 }
 
 .view-switch-btn:hover {
@@ -320,11 +321,13 @@
   color: rgb(2, 132, 199);
   background: white;
   box-shadow: 0 4px 10px rgba(15, 23, 42, 0.1);
+  transform: translateY(-1px) scale(1.03);
 }
 
 .dark .view-switch-pill {
-  background: rgba(15, 23, 42, 0.9);
-  border-color: rgba(71, 85, 105, 0.45);
+  background: rgba(34, 37, 42, 0.95);
+  border-color: rgba(71, 85, 105, 0.35);
+  box-shadow: 0 4px 10px rgba(2, 6, 23, 0.45);
 }
 
 .dark .view-switch-btn {
@@ -334,6 +337,7 @@
 .dark .view-switch-btn.is-active {
   color: rgb(125, 211, 252);
   background: rgba(30, 41, 59, 0.95);
+  box-shadow: 0 6px 12px rgba(2, 132, 199, 0.22);
 }
 
 .card-wrap {
@@ -366,7 +370,6 @@
 
 .dark .card-unified {
   --card-hover-shadow: 0 16px 34px rgba(2, 6, 23, 0.72);
-  box-shadow: 0 1px 2px rgba(2, 6, 23, 0.55);
 }
 
 .bookmark-card-list,

--- a/css/tailwind.css
+++ b/css/tailwind.css
@@ -823,6 +823,10 @@ select {
   inset: 0px;
 }
 
+.left-0 {
+  left: 0px;
+}
+
 .left-3 {
   left: 0.75rem;
 }
@@ -841,6 +845,10 @@ select {
 
 .right-3 {
   right: 0.75rem;
+}
+
+.right-auto {
+  right: auto;
 }
 
 .top-0 {
@@ -1958,8 +1966,9 @@ select {
   gap: 2px;
   padding: 2px;
   border-radius: 9999px;
-  border: 1px solid rgba(148, 163, 184, 0.3);
-  background: rgba(248, 250, 252, 0.95);
+  border: 1px solid rgba(148, 163, 184, 0.25);
+  background: rgba(255, 255, 255, 0.9);
+  box-shadow: 0 4px 10px rgba(15, 23, 42, 0.08);
 }
 
 .view-switch-btn {
@@ -1970,7 +1979,7 @@ select {
   align-items: center;
   justify-content: center;
   color: rgb(100, 116, 139);
-  transition: all 0.2s ease;
+  transition: all 0.22s ease;
 }
 
 .view-switch-btn:hover {
@@ -1981,11 +1990,13 @@ select {
   color: rgb(2, 132, 199);
   background: white;
   box-shadow: 0 4px 10px rgba(15, 23, 42, 0.1);
+  transform: translateY(-1px) scale(1.03);
 }
 
 .dark .view-switch-pill {
-  background: rgba(15, 23, 42, 0.9);
-  border-color: rgba(71, 85, 105, 0.45);
+  background: rgba(34, 37, 42, 0.95);
+  border-color: rgba(71, 85, 105, 0.35);
+  box-shadow: 0 4px 10px rgba(2, 6, 23, 0.45);
 }
 
 .dark .view-switch-btn {
@@ -1995,6 +2006,7 @@ select {
 .dark .view-switch-btn.is-active {
   color: rgb(125, 211, 252);
   background: rgba(30, 41, 59, 0.95);
+  box-shadow: 0 6px 12px rgba(2, 132, 199, 0.22);
 }
 
 .card-wrap {
@@ -2027,7 +2039,6 @@ select {
 
 .dark .card-unified {
   --card-hover-shadow: 0 16px 34px rgba(2, 6, 23, 0.72);
-  box-shadow: 0 1px 2px rgba(2, 6, 23, 0.55);
 }
 
 .bookmark-card-list,
@@ -2264,6 +2275,10 @@ select {
 .dark\:border-gray-800:is(.dark *) {
   --tw-border-opacity: 1;
   border-color: rgb(31 41 55 / var(--tw-border-opacity, 1));
+}
+
+.dark\:bg-slate-900\/80:is(.dark *) {
+  background-color: rgb(15 23 42 / 0.8);
 }
 
 .dark\:text-gray-300:is(.dark *) {

--- a/css/tailwind.css
+++ b/css/tailwind.css
@@ -900,8 +900,16 @@ select {
   margin-right: 4rem;
 }
 
+.mr-3 {
+  margin-right: 0.75rem;
+}
+
 .mr-4 {
   margin-right: 1rem;
+}
+
+.mt-1 {
+  margin-top: 0.25rem;
 }
 
 .mt-2 {
@@ -1008,6 +1016,10 @@ select {
   width: 16rem;
 }
 
+.w-8 {
+  width: 2rem;
+}
+
 .w-9 {
   width: 2.25rem;
 }
@@ -1078,6 +1090,10 @@ select {
 
 .cursor-pointer {
   cursor: pointer;
+}
+
+.grid-cols-1 {
+  grid-template-columns: repeat(1, minmax(0, 1fr));
 }
 
 .grid-cols-2 {
@@ -1193,6 +1209,10 @@ select {
 
 .rounded-full {
   border-radius: 9999px;
+}
+
+.rounded-lg {
+  border-radius: 0.5rem;
 }
 
 .rounded-xl {
@@ -1422,6 +1442,10 @@ select {
 .text-6xl {
   font-size: 3.75rem;
   line-height: 1;
+}
+
+.text-\[11px\] {
+  font-size: 11px;
 }
 
 .text-\[22px\] {
@@ -1912,9 +1936,58 @@ select {
   background: rgba(51, 65, 85, 0.8);
 }
 
+.view-switch-pill {
+  display: inline-flex;
+  align-items: center;
+  gap: 2px;
+  padding: 2px;
+  border-radius: 9999px;
+  border: 1px solid rgba(148, 163, 184, 0.3);
+  background: rgba(248, 250, 252, 0.95);
+}
+
+.view-switch-btn {
+  width: 30px;
+  height: 30px;
+  border-radius: 9999px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  color: rgb(100, 116, 139);
+  transition: all 0.2s ease;
+}
+
+.view-switch-btn:hover {
+  color: rgb(2, 132, 199);
+}
+
+.view-switch-btn.is-active {
+  color: rgb(2, 132, 199);
+  background: white;
+  box-shadow: 0 4px 10px rgba(15, 23, 42, 0.1);
+}
+
+.dark .view-switch-pill {
+  background: rgba(15, 23, 42, 0.9);
+  border-color: rgba(71, 85, 105, 0.45);
+}
+
+.dark .view-switch-btn {
+  color: rgb(148, 163, 184);
+}
+
+.dark .view-switch-btn.is-active {
+  color: rgb(125, 211, 252);
+  background: rgba(30, 41, 59, 0.95);
+}
+
 .card-wrap {
   position: relative;
   min-height: 124px;
+}
+
+.card-wrap-list {
+  min-height: 72px;
 }
 
 .card-unified {
@@ -1937,6 +2010,17 @@ select {
 
 .dark .card-unified:hover {
   box-shadow: 0 16px 34px rgba(2, 6, 23, 0.72);
+}
+
+.bookmark-card-list,
+.folder-card-list {
+  min-height: 72px;
+  height: 72px;
+}
+
+.folder-card-list .folder__svg {
+  width: 46px;
+  height: 36px;
 }
 
 .card-unified:hover h2,
@@ -2299,6 +2383,10 @@ select {
     width: 18rem;
   }
 
+  .lg\:grid-cols-2 {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
   .lg\:grid-cols-4 {
     grid-template-columns: repeat(4, minmax(0, 1fr));
   }
@@ -2327,6 +2415,10 @@ select {
 }
 
 @media (min-width: 1280px) {
+  .xl\:grid-cols-3 {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+  }
+
   .xl\:grid-cols-4 {
     grid-template-columns: repeat(4, minmax(0, 1fr));
   }

--- a/css/tailwind.css
+++ b/css/tailwind.css
@@ -799,6 +799,10 @@ select {
   pointer-events: none;
 }
 
+.collapse {
+  visibility: collapse;
+}
+
 .fixed {
   position: fixed;
 }
@@ -1036,8 +1040,16 @@ select {
   min-width: 0px;
 }
 
+.min-w-\[180px\] {
+  min-width: 180px;
+}
+
 .max-w-2xl {
   max-width: 42rem;
+}
+
+.max-w-\[220px\] {
+  max-width: 220px;
 }
 
 .max-w-xs {
@@ -1090,6 +1102,10 @@ select {
 
 .cursor-pointer {
   cursor: pointer;
+}
+
+.resize {
+  resize: both;
 }
 
 .grid-cols-1 {
@@ -1196,6 +1212,10 @@ select {
 .truncate {
   overflow: hidden;
   text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.whitespace-nowrap {
   white-space: nowrap;
 }
 
@@ -1999,17 +2019,18 @@ select {
   left: 0;
   right: 0;
   transition: transform 0.25s ease, box-shadow 0.25s ease;
+  --card-hover-shadow: 0 14px 30px rgba(15, 23, 42, 0.18);
 }
 
 .card-unified:hover {
   transform: scale(1.06);
   z-index: 8;
-  box-shadow: 0 14px 30px rgba(15, 23, 42, 0.18);
+  box-shadow: var(--card-hover-shadow);
   height: auto;
 }
 
-.dark .card-unified:hover {
-  box-shadow: 0 16px 34px rgba(2, 6, 23, 0.72);
+.dark .card-unified {
+  --card-hover-shadow: 0 16px 34px rgba(2, 6, 23, 0.72);
 }
 
 .bookmark-card-list,

--- a/css/tailwind.css
+++ b/css/tailwind.css
@@ -1890,6 +1890,10 @@ select {
   transition: all 0.2s ease;
 }
 
+.icon-action-btn.hidden {
+  display: none !important;
+}
+
 .icon-action-btn:hover {
   color: rgb(2, 132, 199);
   border-color: rgba(14, 165, 233, 0.5);

--- a/css/tailwind.css
+++ b/css/tailwind.css
@@ -1048,10 +1048,6 @@ select {
   max-width: 42rem;
 }
 
-.max-w-\[220px\] {
-  max-width: 220px;
-}
-
 .max-w-xs {
   max-width: 20rem;
 }
@@ -2031,6 +2027,7 @@ select {
 
 .dark .card-unified {
   --card-hover-shadow: 0 16px 34px rgba(2, 6, 23, 0.72);
+  box-shadow: 0 1px 2px rgba(2, 6, 23, 0.55);
 }
 
 .bookmark-card-list,

--- a/css/tailwind.css
+++ b/css/tailwind.css
@@ -823,6 +823,10 @@ select {
   inset: 0px;
 }
 
+.bottom-6 {
+  bottom: 1.5rem;
+}
+
 .left-0 {
   left: 0px;
 }
@@ -845,6 +849,10 @@ select {
 
 .right-3 {
   right: 0.75rem;
+}
+
+.right-6 {
+  right: 1.5rem;
 }
 
 .right-auto {
@@ -1282,10 +1290,6 @@ select {
   border-color: rgb(226 232 240 / 0.7);
 }
 
-.bg-gray-900\/80 {
-  background-color: rgb(17 24 39 / 0.8);
-}
-
 .bg-green-600 {
   --tw-bg-opacity: 1;
   background-color: rgb(22 163 74 / var(--tw-bg-opacity, 1));
@@ -1311,6 +1315,10 @@ select {
 
 .bg-white\/90 {
   background-color: rgb(255 255 255 / 0.9);
+}
+
+.bg-zinc-900\/55 {
+  background-color: rgb(24 24 27 / 0.55);
 }
 
 .fill-gray-100 {
@@ -2092,6 +2100,15 @@ select {
   transform: translateY(0) scale(1);
 }
 
+#bookmarks {
+  transition: opacity 0.2s ease, transform 0.2s ease;
+}
+
+#bookmarks.view-transitioning {
+  opacity: 0.55;
+  transform: translateY(4px);
+}
+
 .nav-sublist {
   max-height: 0;
   overflow: hidden;
@@ -2277,8 +2294,8 @@ select {
   border-color: rgb(31 41 55 / var(--tw-border-opacity, 1));
 }
 
-.dark\:bg-slate-900\/80:is(.dark *) {
-  background-color: rgb(15 23 42 / 0.8);
+.dark\:bg-zinc-900\/80:is(.dark *) {
+  background-color: rgb(24 24 27 / 0.8);
 }
 
 .dark\:text-gray-300:is(.dark *) {
@@ -2319,6 +2336,10 @@ select {
 .dark\:text-white:is(.dark *) {
   --tw-text-opacity: 1;
   color: rgb(255 255 255 / var(--tw-text-opacity, 1));
+}
+
+.dark\:ring-slate-800\/90:is(.dark *) {
+  --tw-ring-color: rgb(30 41 59 / 0.9);
 }
 
 .dark\:ring-white\/10:is(.dark *) {

--- a/css/tailwind.css
+++ b/css/tailwind.css
@@ -1607,10 +1607,6 @@ select {
   --tw-ring-color: rgb(17 24 39 / 0.05);
 }
 
-.ring-slate-200\/70 {
-  --tw-ring-color: rgb(226 232 240 / 0.7);
-}
-
 .blur {
   --tw-blur: blur(8px);
   filter: var(--tw-blur) var(--tw-brightness) var(--tw-contrast) var(--tw-grayscale) var(--tw-hue-rotate) var(--tw-invert) var(--tw-saturate) var(--tw-sepia) var(--tw-drop-shadow);
@@ -2226,10 +2222,6 @@ select {
   text-decoration-line: underline;
 }
 
-.hover\:ring-slate-200\/70:hover {
-  --tw-ring-color: rgb(226 232 240 / 0.7);
-}
-
 .focus\:outline-none:focus {
   outline: 2px solid transparent;
   outline-offset: 2px;
@@ -2289,6 +2281,10 @@ select {
   border-color: rgb(31 41 55 / var(--tw-border-opacity, 1));
 }
 
+.dark\:border-slate-800\/90:is(.dark *) {
+  border-color: rgb(30 41 59 / 0.9);
+}
+
 .dark\:bg-zinc-900\/80:is(.dark *) {
   background-color: rgb(24 24 27 / 0.8);
 }
@@ -2333,10 +2329,6 @@ select {
   color: rgb(255 255 255 / var(--tw-text-opacity, 1));
 }
 
-.dark\:ring-slate-800\/90:is(.dark *) {
-  --tw-ring-color: rgb(30 41 59 / 0.9);
-}
-
 .dark\:ring-white\/10:is(.dark *) {
   --tw-ring-color: rgb(255 255 255 / 0.1);
 }
@@ -2344,10 +2336,6 @@ select {
 .dark\:hover\:text-gray-200:hover:is(.dark *) {
   --tw-text-opacity: 1;
   color: rgb(229 231 235 / var(--tw-text-opacity, 1));
-}
-
-.dark\:hover\:ring-slate-800\/90:hover:is(.dark *) {
-  --tw-ring-color: rgb(30 41 59 / 0.9);
 }
 
 .dark\:hover\:ring-white\/20:hover:is(.dark *) {

--- a/css/tailwind.css
+++ b/css/tailwind.css
@@ -1116,6 +1116,10 @@ select {
   gap: 0.5rem;
 }
 
+.gap-3 {
+  gap: 0.75rem;
+}
+
 .gap-4 {
   gap: 1rem;
 }
@@ -1343,6 +1347,11 @@ select {
 .px-6 {
   padding-left: 1.5rem;
   padding-right: 1.5rem;
+}
+
+.py-0\.5 {
+  padding-top: 0.125rem;
+  padding-bottom: 0.125rem;
 }
 
 .py-1 {
@@ -1836,6 +1845,19 @@ select {
   color: rgb(71, 85, 105);
   box-shadow: 0 4px 10px rgba(15, 23, 42, 0.08);
   border: 1px solid rgba(148, 163, 184, 0.25);
+  transition: all 0.2s ease;
+}
+
+.icon-action-btn:hover {
+  color: rgb(2, 132, 199);
+  border-color: rgba(14, 165, 233, 0.5);
+  background: rgba(240, 249, 255, 0.95);
+  box-shadow: 0 6px 14px rgba(14, 165, 233, 0.2);
+}
+
+.icon-action-btn:focus-visible {
+  outline: 2px solid rgba(14, 165, 233, 0.45);
+  outline-offset: 2px;
 }
 
 .menu-panel {
@@ -1868,6 +1890,13 @@ select {
   background: rgba(34, 37, 42, 0.95);
   color: rgb(203, 213, 225);
   border-color: rgba(71, 85, 105, 0.35);
+}
+
+.dark .icon-action-btn:hover {
+  color: rgb(125, 211, 252);
+  border-color: rgba(56, 189, 248, 0.55);
+  background: rgba(15, 23, 42, 0.95);
+  box-shadow: 0 8px 16px rgba(2, 132, 199, 0.28);
 }
 
 .dark .menu-panel {
@@ -2057,6 +2086,11 @@ select {
   color: rgb(107 114 128 / var(--tw-text-opacity, 1));
 }
 
+.hover\:text-gray-700:hover {
+  --tw-text-opacity: 1;
+  color: rgb(55 65 81 / var(--tw-text-opacity, 1));
+}
+
 .hover\:text-green-500:hover {
   --tw-text-opacity: 1;
   color: rgb(34 197 94 / var(--tw-text-opacity, 1));
@@ -2174,6 +2208,11 @@ select {
   --tw-ring-color: rgb(255 255 255 / 0.1);
 }
 
+.dark\:hover\:text-gray-200:hover:is(.dark *) {
+  --tw-text-opacity: 1;
+  color: rgb(229 231 235 / var(--tw-text-opacity, 1));
+}
+
 .dark\:hover\:ring-white\/20:hover:is(.dark *) {
   --tw-ring-color: rgb(255 255 255 / 0.2);
 }
@@ -2244,6 +2283,10 @@ select {
     z-index: 50;
   }
 
+  .lg\:block {
+    display: block;
+  }
+
   .lg\:flex {
     display: flex;
   }
@@ -2272,6 +2315,10 @@ select {
   .lg\:px-8 {
     padding-left: 2rem;
     padding-right: 2rem;
+  }
+
+  .lg\:pl-0 {
+    padding-left: 0px;
   }
 
   .lg\:pl-72 {

--- a/css/tailwind.css
+++ b/css/tailwind.css
@@ -1300,10 +1300,6 @@ select {
   background-color: rgb(248 250 252 / var(--tw-bg-opacity, 1));
 }
 
-.bg-slate-900\/40 {
-  background-color: rgb(15 23 42 / 0.4);
-}
-
 .bg-white {
   --tw-bg-opacity: 1;
   background-color: rgb(255 255 255 / var(--tw-bg-opacity, 1));
@@ -1630,12 +1626,6 @@ select {
   backdrop-filter: var(--tw-backdrop-blur) var(--tw-backdrop-brightness) var(--tw-backdrop-contrast) var(--tw-backdrop-grayscale) var(--tw-backdrop-hue-rotate) var(--tw-backdrop-invert) var(--tw-backdrop-opacity) var(--tw-backdrop-saturate) var(--tw-backdrop-sepia);
 }
 
-.backdrop-blur-sm {
-  --tw-backdrop-blur: blur(4px);
-  -webkit-backdrop-filter: var(--tw-backdrop-blur) var(--tw-backdrop-brightness) var(--tw-backdrop-contrast) var(--tw-backdrop-grayscale) var(--tw-backdrop-hue-rotate) var(--tw-backdrop-invert) var(--tw-backdrop-opacity) var(--tw-backdrop-saturate) var(--tw-backdrop-sepia);
-  backdrop-filter: var(--tw-backdrop-blur) var(--tw-backdrop-brightness) var(--tw-backdrop-contrast) var(--tw-backdrop-grayscale) var(--tw-backdrop-hue-rotate) var(--tw-backdrop-invert) var(--tw-backdrop-opacity) var(--tw-backdrop-saturate) var(--tw-backdrop-sepia);
-}
-
 .backdrop-filter {
   -webkit-backdrop-filter: var(--tw-backdrop-blur) var(--tw-backdrop-brightness) var(--tw-backdrop-contrast) var(--tw-backdrop-grayscale) var(--tw-backdrop-hue-rotate) var(--tw-backdrop-invert) var(--tw-backdrop-opacity) var(--tw-backdrop-saturate) var(--tw-backdrop-sepia);
   backdrop-filter: var(--tw-backdrop-blur) var(--tw-backdrop-brightness) var(--tw-backdrop-contrast) var(--tw-backdrop-grayscale) var(--tw-backdrop-hue-rotate) var(--tw-backdrop-invert) var(--tw-backdrop-opacity) var(--tw-backdrop-saturate) var(--tw-backdrop-sepia);
@@ -1930,6 +1920,7 @@ select {
 }
 
 .menu-item {
+  display: block;
   width: 100%;
   text-align: left;
   font-size: 13px;
@@ -2235,6 +2226,10 @@ select {
   text-decoration-line: underline;
 }
 
+.hover\:ring-slate-200\/70:hover {
+  --tw-ring-color: rgb(226 232 240 / 0.7);
+}
+
 .focus\:outline-none:focus {
   outline: 2px solid transparent;
   outline-offset: 2px;
@@ -2349,6 +2344,10 @@ select {
 .dark\:hover\:text-gray-200:hover:is(.dark *) {
   --tw-text-opacity: 1;
   color: rgb(229 231 235 / var(--tw-text-opacity, 1));
+}
+
+.dark\:hover\:ring-slate-800\/90:hover:is(.dark *) {
+  --tw-ring-color: rgb(30 41 59 / 0.9);
 }
 
 .dark\:hover\:ring-white\/20:hover:is(.dark *) {

--- a/index.html
+++ b/index.html
@@ -111,7 +111,7 @@
     </div>
 
     <!-- Static Sidebar for Desktop -->
-    <div class="hidden lg:fixed lg:inset-y-0 lg:z-50 lg:flex lg:w-72 lg:flex-col">
+    <div id="desktopSidebarContainer" class="hidden lg:fixed lg:inset-y-0 lg:z-50 lg:flex lg:w-72 lg:flex-col transition-transform duration-300 ease-in-out">
       <div
         class="flex flex-col border-r border-gray-200 dark:pintree-border-gray-800 bg-white px-4 h-full font-semibold dark:pintree-bg-gray-900">
         <div class="flex p-0 h-16 shrink-0 items-center">
@@ -129,12 +129,20 @@
     </div>
 
     <!-- Main Content Area -->
-    <div class="lg:pl-72 dark:pintree-bg-gray-900 flex flex-col min-h-screen">
+    <div id="mainLayout" class="lg:pl-72 dark:pintree-bg-gray-900 flex flex-col min-h-screen transition-all duration-300 ease-in-out">
       <div
         class="items-center justify-between sticky top-0 z-40 flex h-16 shrink-0 gap-x-4 border-b border-slate-200/70 dark:pintree-border-gray-800 bg-white/85 dark:pintree-bg-gray-900 px-4 shadow-sm backdrop-blur sm:gap-x-6 sm:px-6 lg:px-8">
         <div class="h-full items-center flex flex-1 gap-x-4 self-stretch lg:gap-x-6 justify-between">
           <div class="flex gap-x-3 justify-between items-center">
             <img class="pl-2 h-8 w-auto lg:hidden" src="assets/logo.svg" alt="Pintree">
+            <button id="toggle-desktop-sidebar-button" class="hidden lg:flex items-center justify-center w-9 h-9 icon-action-btn" aria-label="Toggle desktop sidebar">
+              <svg id="desktopSidebarOpenIcon" class="h-5 w-5" viewBox="0 0 24 24" fill="none" stroke="currentColor">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M15 19l-7-7 7-7"></path>
+              </svg>
+              <svg id="desktopSidebarClosedIcon" class="h-5 w-5 hidden" viewBox="0 0 24 24" fill="none" stroke="currentColor">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M9 5l7 7-7 7"></path>
+              </svg>
+            </button>
             <button id="open-sidebar-button" class="lg:hidden flex items-center justify-center w-9 h-9">
               <span class="sr-only">Open sidebar</span>
               <svg class="h-5 w-5 text-gray-400" viewBox="0 0 1024 1024" width="20" height="20" fill="currentColor">
@@ -232,7 +240,19 @@
               </svg>
             </a>
           </div> -->
-          <div class="mt-8 md:order-1 md:mt-0">
+          <div class="mt-8 md:order-1 md:mt-0 space-y-2">
+            <div class="flex justify-center items-center gap-3 text-xs text-gray-500 dark:text-gray-400">
+              <a href="https://github.com/TonyBlur/tblu-bookmark" target="_blank" rel="noopener noreferrer" class="inline-flex items-center gap-1 text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-200">
+                <span class="sr-only">GitHub repository</span>
+                <svg class="h-4 w-4" fill="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+                  <path fill-rule="evenodd"
+                    d="M12 2C6.477 2 2 6.484 2 12.017c0 4.425 2.865 8.18 6.839 9.504.5.092.682-.217.682-.483 0-.237-.008-.868-.013-1.703-2.782.605-3.369-1.343-3.369-1.343-.454-1.158-1.11-1.466-1.11-1.466-.908-.62.069-.608.069-.608 1.003.07 1.531 1.032 1.531 1.032.892 1.53 2.341 1.088 2.91.832.092-.647.35-1.088.636-1.338-2.22-.253-4.555-1.113-4.555-4.951 0-1.093.39-1.988 1.029-2.688-.103-.253-.446-1.272.098-2.65 0 0 .84-.27 2.75 1.026A9.564 9.564 0 0112 6.844c.85.004 1.705.115 2.504.337 1.909-1.296 2.747-1.027 2.747-1.027.546 1.379.202 2.398.1 2.651.64.7 1.028 1.595 1.028 2.688 0 3.848-2.339 4.695-4.566 4.943.359.309.678.92.678 1.855 0 1.338-.012 2.419-.012 2.747 0 .268.18.58.688.482A10.019 10.019 0 0022 12.017C22 6.484 17.522 2 12 2z"
+                    clip-rule="evenodd" />
+                </svg>
+                <span>GitHub</span>
+              </a>
+              <span id="githubReleaseVersion" class="inline-flex items-center px-2 py-0.5 rounded-full border border-slate-200 dark:pintree-border-gray-700">Loading release…</span>
+            </div>
             <p class="text-center text-xs leading-5 text-gray-500 dark:text-gray-400 flex justify-center items-center">
               &copy; <span id="currentYear"></span>&nbsp;Built with
               <a href="https://pintree.io" class="text-green-600 hover:text-green-500 flex items-center ml-1"
@@ -336,12 +356,13 @@
     const appState = {
       rawData: [],
       activePath: [],
-      activeTag: null,
+      activeTags: [],
       query: '',
       flattened: [],
       tagRules: [],
       locale: localStorage.getItem('tblu-locale') || (navigator.language?.toLowerCase().startsWith('zh') ? 'zh' : 'en'),
       themeMode: localStorage.getItem('tblu-theme-mode') || 'system',
+      desktopSidebarCollapsed: localStorage.getItem('tblu-desktop-sidebar-collapsed') === '1',
     };
 
     const DOM = {
@@ -372,6 +393,12 @@
       themeMenu: document.getElementById('themeMenu'),
       sunIcon: document.getElementById('sunIcon'),
       moonIcon: document.getElementById('moonIcon'),
+      desktopSidebarContainer: document.getElementById('desktopSidebarContainer'),
+      mainLayout: document.getElementById('mainLayout'),
+      toggleDesktopSidebarButton: document.getElementById('toggle-desktop-sidebar-button'),
+      desktopSidebarOpenIcon: document.getElementById('desktopSidebarOpenIcon'),
+      desktopSidebarClosedIcon: document.getElementById('desktopSidebarClosedIcon'),
+      githubReleaseVersion: document.getElementById('githubReleaseVersion'),
     };
 
     function t(key) {
@@ -404,16 +431,18 @@
       renderBookmarks(first?.children || rootFolders, [{ title: first?.title || t('home'), children: first?.children || rootFolders }]);
     }
 
-    function remapActiveTagForLocale(previousLocale, nextLocale) {
-      if (!appState.activeTag || !appState.tagRules.length) return;
-      const rule = appState.tagRules.find(r => {
-        if (!r || typeof r.tag !== 'object') return false;
-        const prevLabel = r.tag[previousLocale];
-        const nextLabel = r.tag[nextLocale];
-        return appState.activeTag === prevLabel || appState.activeTag === nextLabel;
+    function remapActiveTagsForLocale(previousLocale, nextLocale) {
+      if (!appState.activeTags.length || !appState.tagRules.length) return;
+      appState.activeTags = appState.activeTags.map(activeTag => {
+        const rule = appState.tagRules.find(r => {
+          if (!r || typeof r.tag !== 'object') return false;
+          const prevLabel = r.tag[previousLocale];
+          const nextLabel = r.tag[nextLocale];
+          return activeTag === prevLabel || activeTag === nextLabel;
+        });
+        if (!rule || typeof rule.tag !== 'object') return activeTag;
+        return rule.tag[nextLocale] || rule.tag.zh || rule.tag.en || activeTag;
       });
-      if (!rule || typeof rule.tag !== 'object') return;
-      appState.activeTag = rule.tag[nextLocale] || rule.tag.zh || rule.tag.en || appState.activeTag;
     }
 
     function normalize(str = '') {
@@ -522,13 +551,16 @@
       return dp[a.length][b.length];
     }
 
-    function searchInFlattenedData(query, selectedTag) {
+    function searchInFlattenedData(query, selectedTags = []) {
       const q = normalize(query);
       return appState.flattened
         .map(item => {
           const text = [item.title, item.url || '', ...(item.tags || [])].join(' ');
           const score = fuzzyScore(text, q);
-          const tagMatch = selectedTag ? item.tags.some(t => normalize(t) === normalize(selectedTag)) : true;
+          const normalizedTags = (item.tags || []).map(tag => normalize(tag));
+          const tagMatch = selectedTags.length
+            ? selectedTags.every(tag => normalizedTags.includes(normalize(tag)))
+            : true;
           const keywordMatch = !q || score >= 0.55;
           return { item, score, tagMatch, keywordMatch };
         })
@@ -538,8 +570,19 @@
         .sort((a, b) => b.score - a.score)
         .map(({ item, tagMatch }) => ({
           item,
-          hitType: selectedTag && tagMatch ? 'tag' : item.type,
+          hitType: selectedTags.length && tagMatch ? 'tag' : item.type,
         }));
+    }
+
+    function setTagFilter(tag) {
+      if (!tag) return;
+      if (!appState.activeTags.some(item => normalize(item) === normalize(tag))) {
+        appState.activeTags.push(tag);
+      }
+      DOM.resetTagFilter.classList.toggle('hidden', !appState.activeTags.length);
+      renderTagFilters();
+      if (DOM.searchModal.classList.contains('hidden')) openSearchModal();
+      performSearch();
     }
 
     function createTagBadge(tag, onClick, active = false) {
@@ -565,16 +608,20 @@
         .slice(0, 40)
         .forEach(([tag, count]) => {
           const badge = createTagBadge(tag, () => {
-            appState.activeTag = appState.activeTag === tag ? null : tag;
-            DOM.resetTagFilter.classList.toggle('hidden', !appState.activeTag);
+            if (appState.activeTags.some(item => normalize(item) === normalize(tag))) {
+              appState.activeTags = appState.activeTags.filter(item => normalize(item) !== normalize(tag));
+            } else {
+              appState.activeTags.push(tag);
+            }
+            DOM.resetTagFilter.classList.toggle('hidden', !appState.activeTags.length);
             performSearch();
             renderTagFilters();
-          }, appState.activeTag === tag);
+          }, appState.activeTags.some(item => normalize(item) === normalize(tag)));
           badge.title = `${count} ${t('records')}`;
           DOM.searchTagFilters.appendChild(badge);
         });
-      if (appState.activeTag) {
-        DOM.selectedTagIndicator.textContent = `${t('tagFilter')}: ${appState.activeTag}`;
+      if (appState.activeTags.length) {
+        DOM.selectedTagIndicator.textContent = `${t('tagFilter')}: ${appState.activeTags.join(', ')}`;
         DOM.selectedTagIndicator.classList.remove('hidden');
       } else {
         DOM.selectedTagIndicator.classList.add('hidden');
@@ -617,9 +664,14 @@
       const tagWrap = document.createElement('div');
       tagWrap.className = 'flex flex-wrap gap-1 mt-2';
       tags.slice(0, 4).forEach(tag => {
-        const chip = document.createElement('span');
+        const chip = document.createElement('button');
+        chip.type = 'button';
         chip.className = 'mini-chip';
         chip.textContent = tag;
+        chip.addEventListener('click', event => {
+          event.stopPropagation();
+          setTagFilter(tag);
+        });
         tagWrap.appendChild(chip);
       });
 
@@ -798,9 +850,11 @@
         return;
       }
       tags.forEach(tag => {
-        const chip = document.createElement('span');
+        const chip = document.createElement('button');
+        chip.type = 'button';
         chip.className = 'mini-chip';
         chip.textContent = tag;
+        chip.addEventListener('click', () => setTagFilter(tag));
         DOM.folderTags.appendChild(chip);
       });
       DOM.folderTagSection.classList.remove('hidden');
@@ -835,15 +889,36 @@
     function performSearch() {
       const query = DOM.searchInput.value.trim();
       appState.query = query;
-      DOM.clearSearchButton.classList.toggle('hidden', !query && !appState.activeTag);
+      DOM.clearSearchButton.classList.toggle('hidden', !query && !appState.activeTags.length);
 
-      if (!query && !appState.activeTag) {
+      if (!query && !appState.activeTags.length) {
         DOM.searchResultsPanel.innerHTML = '';
         return;
       }
 
-      const results = searchInFlattenedData(query, appState.activeTag);
+      const results = searchInFlattenedData(query, appState.activeTags);
       renderSearchResultsPanel(results);
+    }
+
+    function applyDesktopSidebarState() {
+      DOM.desktopSidebarContainer.classList.toggle('-translate-x-full', appState.desktopSidebarCollapsed);
+      DOM.mainLayout.classList.toggle('lg:pl-0', appState.desktopSidebarCollapsed);
+      DOM.mainLayout.classList.toggle('lg:pl-72', !appState.desktopSidebarCollapsed);
+      DOM.desktopSidebarOpenIcon.classList.toggle('hidden', appState.desktopSidebarCollapsed);
+      DOM.desktopSidebarClosedIcon.classList.toggle('hidden', !appState.desktopSidebarCollapsed);
+      localStorage.setItem('tblu-desktop-sidebar-collapsed', appState.desktopSidebarCollapsed ? '1' : '0');
+    }
+
+    async function fetchGithubReleaseVersion() {
+      if (!DOM.githubReleaseVersion) return;
+      try {
+        const response = await fetch('https://api.github.com/repos/TonyBlur/tblu-bookmark/releases/latest');
+        if (!response.ok) throw new Error(`HTTP ${response.status}`);
+        const data = await response.json();
+        DOM.githubReleaseVersion.textContent = data.tag_name || data.name || 'No release';
+      } catch (error) {
+        DOM.githubReleaseVersion.textContent = 'No release';
+      }
     }
 
     function closeSidebar() {
@@ -959,23 +1034,28 @@
       if (event.key === 'Escape') closeSearchModal();
     });
     DOM.searchInput.addEventListener('input', () => {
-      DOM.clearSearchButton.classList.toggle('hidden', !DOM.searchInput.value.trim() && !appState.activeTag);
+      DOM.clearSearchButton.classList.toggle('hidden', !DOM.searchInput.value.trim() && !appState.activeTags.length);
       performSearch();
     });
 
     DOM.clearSearchButton.addEventListener('click', () => {
       DOM.searchInput.value = '';
-      appState.activeTag = null;
+      appState.activeTags = [];
       DOM.resetTagFilter.classList.add('hidden');
       renderTagFilters();
       performSearch();
     });
 
     DOM.resetTagFilter.addEventListener('click', () => {
-      appState.activeTag = null;
+      appState.activeTags = [];
       DOM.resetTagFilter.classList.add('hidden');
       renderTagFilters();
       performSearch();
+    });
+
+    DOM.toggleDesktopSidebarButton.addEventListener('click', () => {
+      appState.desktopSidebarCollapsed = !appState.desktopSidebarCollapsed;
+      applyDesktopSidebarState();
     });
 
     DOM.searchTagFilterButton.addEventListener('click', (e) => {
@@ -997,7 +1077,7 @@
       btn.addEventListener('click', () => {
         const previousLocale = appState.locale;
         appState.locale = btn.dataset.locale;
-        remapActiveTagForLocale(previousLocale, appState.locale);
+        remapActiveTagsForLocale(previousLocale, appState.locale);
         localStorage.setItem('tblu-locale', appState.locale);
         DOM.languageMenu.classList.add('hidden');
         applyLocale();
@@ -1027,7 +1107,9 @@
       if (appState.themeMode === 'system') applyThemeMode('system');
     });
     applyThemeMode(appState.themeMode);
+    applyDesktopSidebarState();
     applyLocale();
+    fetchGithubReleaseVersion();
 
     window.addEventListener('load', () => {
       if (window.bookmarkDataURL) loadAndRenderBookmarks(window.bookmarkDataURL);

--- a/index.html
+++ b/index.html
@@ -131,7 +131,7 @@
     <!-- Main Content Area -->
     <div id="mainLayout" class="lg:pl-72 dark:pintree-bg-gray-900 flex flex-col min-h-screen transition-all duration-300 ease-in-out">
       <div
-        class="items-center justify-between sticky top-0 z-40 flex h-16 shrink-0 gap-x-4 border-b border-slate-200/70 dark:pintree-border-gray-800 bg-white/85 dark:pintree-bg-gray-900 px-4 shadow-sm backdrop-blur sm:gap-x-6 sm:px-6 lg:px-8">
+        class="items-center justify-between sticky top-0 z-40 flex h-16 shrink-0 gap-x-4 border-b border-slate-200/70 dark:pintree-border-gray-800 bg-white/85 dark:bg-slate-900/80 px-4 shadow-sm backdrop-blur sm:gap-x-6 sm:px-6 lg:px-8">
         <div class="h-full items-center flex flex-1 gap-x-4 self-stretch lg:gap-x-6 justify-between">
           <div class="flex gap-x-3 justify-between items-center">
             <img class="pl-2 h-8 w-auto lg:hidden" src="assets/logo.svg" alt="Pintree">
@@ -202,9 +202,9 @@
           <div class="loader ease-linear rounded-full border-2 border-t-2 border-gray-400 h-6 w-6"></div>
         </div>
         <div id="breadcrumbs" class="mt-2 px-6 lg:px-8 text-sm text-gray-400 flex justify-between items-center gap-3">
-          <div id="breadcrumbs-path" class="relative flex items-center gap-1 min-w-0 flex-1 whitespace-nowrap overflow-hidden">
+          <div id="breadcrumbs-path" class="relative flex items-center gap-1 min-w-0 flex-1 whitespace-nowrap">
             <!-- Breadcrumbs / collapse menu will be inserted here -->
-            <div id="breadcrumbCollapseMenu" class="menu-panel hidden min-w-[180px]"></div>
+            <div id="breadcrumbCollapseMenu" class="menu-panel hidden min-w-[180px] left-0 right-auto"></div>
           </div>
           <div id="viewModeSwitch" class="view-switch-pill shrink-0" role="group" aria-label="View mode switch">
             <button id="gridViewButton" class="view-switch-btn is-active" type="button" title="Grid view">
@@ -651,7 +651,7 @@
       wrap.className = `card-wrap ${appState.viewMode === 'list' ? 'card-wrap-list' : ''}`;
 
       const card = document.createElement('div');
-      card.className = `bookmark-card card-unified cursor-pointer bg-white shadow-sm ring-1 ring-slate-200/70 dark:pintree-ring-gray-800 rounded-2xl dark:pintree-bg-gray-900 dark:hover:pintree-bg-gray-800 ${appState.viewMode === 'list'
+      card.className = `bookmark-card card-unified cursor-pointer bg-white ring-1 ring-slate-200/70 dark:pintree-ring-gray-800 rounded-2xl dark:pintree-bg-gray-900 dark:hover:pintree-bg-gray-800 ${appState.viewMode === 'list'
         ? 'bookmark-card-list p-2 flex items-center'
         : 'p-4 flex items-start'}`;
       card.onclick = () => window.open(url, '_blank', 'noopener,noreferrer');
@@ -718,7 +718,7 @@
       wrap.className = `card-wrap ${appState.viewMode === 'list' ? 'card-wrap-list' : ''}`;
 
       const card = document.createElement('div');
-      card.className = `folder-card card-unified text-gray rounded-2xl cursor-pointer ${appState.viewMode === 'list'
+      card.className = `folder-card card-unified text-gray rounded-2xl cursor-pointer ring-1 ring-slate-200/70 dark:pintree-ring-gray-800 dark:pintree-bg-gray-900 dark:hover:pintree-bg-gray-800 ${appState.viewMode === 'list'
         ? 'folder-card-list flex items-center p-2'
         : 'flex flex-col items-center p-2'}`;
       card.onclick = () => {

--- a/index.html
+++ b/index.html
@@ -299,7 +299,7 @@
     </svg>
   </button>
 
-  <div id="searchModal" class="fixed inset-0 z-[60] hidden items-start justify-center bg-slate-900/40 p-4 pt-20 backdrop-blur-sm">
+  <div id="searchModal" class="fixed inset-0 z-[60] hidden items-start justify-center bg-zinc-900/55 p-4 pt-20 backdrop-blur" style="backdrop-filter: blur(14px);">
     <div class="panel-card w-full max-w-2xl p-4">
       <div class="flex items-center gap-2 mb-3">
         <div class="relative flex-1">
@@ -661,7 +661,7 @@
       wrap.className = `card-wrap ${appState.viewMode === 'list' ? 'card-wrap-list' : ''}`;
 
       const card = document.createElement('div');
-      card.className = `bookmark-card card-unified cursor-pointer bg-white ring-1 ring-slate-200/70 dark:ring-slate-800/90 rounded-2xl dark:pintree-bg-gray-900 dark:hover:pintree-bg-gray-800 ${appState.viewMode === 'list'
+      card.className = `bookmark-card card-unified cursor-pointer bg-white ring-1 ring-slate-200/70 hover:ring-slate-200/70 dark:ring-slate-800/90 dark:hover:ring-slate-800/90 rounded-2xl dark:pintree-bg-gray-900 dark:hover:pintree-bg-gray-800 ${appState.viewMode === 'list'
         ? 'bookmark-card-list p-2 flex items-center'
         : 'p-4 flex items-start'}`;
       card.onclick = () => window.open(url, '_blank', 'noopener,noreferrer');
@@ -979,6 +979,10 @@
       document.body.classList.toggle('overflow-hidden', locked);
     }
 
+    function updateBackToTopVisibility() {
+      DOM.backToTopButton.classList.toggle('hidden', window.scrollY < 280);
+    }
+
     function performSearch() {
       const query = DOM.searchInput.value.trim();
       appState.query = query;
@@ -1218,12 +1222,13 @@
       if (appState.activePath?.length) renderBreadcrumbs(appState.activePath);
     });
     window.addEventListener('scroll', () => {
-      DOM.backToTopButton.classList.toggle('hidden', window.scrollY < 280);
+      updateBackToTopVisibility();
     });
     applyThemeMode(appState.themeMode);
     applyDesktopSidebarState();
     applyViewMode(appState.viewMode);
     applyLocale();
+    updateBackToTopVisibility();
     fetchGithubReleaseVersion();
 
     window.addEventListener('load', () => {

--- a/index.html
+++ b/index.html
@@ -153,6 +153,18 @@
                   clip-rule="evenodd"></path>
               </svg>
             </button>
+            <div id="viewModeSwitch" class="view-switch-pill" role="group" aria-label="View mode switch">
+              <button id="gridViewButton" class="view-switch-btn is-active" type="button" title="Grid view">
+                <svg class="h-4 w-4" viewBox="0 0 24 24" fill="none" stroke="currentColor">
+                  <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M4 4h6v6H4V4Zm10 0h6v6h-6V4ZM4 14h6v6H4v-6Zm10 0h6v6h-6v-6Z"></path>
+                </svg>
+              </button>
+              <button id="listViewButton" class="view-switch-btn" type="button" title="List view">
+                <svg class="h-4 w-4" viewBox="0 0 24 24" fill="none" stroke="currentColor">
+                  <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M4 7h16M4 12h16M4 17h16"></path>
+                </svg>
+              </button>
+            </div>
           </div>
           <div class="relative flex items-center gap-2">
             <div class="relative">
@@ -315,6 +327,8 @@
       zh: {
         clear: '清除',
         clearTags: '清除标签',
+        gridView: '网格视图',
+        listView: '列表视图',
         tagFilter: 'Tag 筛选',
         searchPlaceholder: '搜索书签 / 标签 / 网址...',
         noResultsTitle: '没有找到匹配内容',
@@ -333,6 +347,8 @@
       en: {
         clear: 'Clear',
         clearTags: 'Clear tags',
+        gridView: 'Grid view',
+        listView: 'List view',
         tagFilter: 'Tag filters',
         searchPlaceholder: 'Search bookmarks / tags / URLs...',
         noResultsTitle: 'No matching results',
@@ -360,6 +376,7 @@
       locale: localStorage.getItem('tblu-locale') || (navigator.language?.toLowerCase().startsWith('zh') ? 'zh' : 'en'),
       themeMode: localStorage.getItem('tblu-theme-mode') || 'system',
       desktopSidebarCollapsed: localStorage.getItem('tblu-desktop-sidebar-collapsed') === '1',
+      viewMode: localStorage.getItem('tblu-view-mode') || 'grid',
     };
 
     const DOM = {
@@ -395,6 +412,9 @@
       desktopSidebarOpenIcon: document.getElementById('desktopSidebarOpenIcon'),
       desktopSidebarClosedIcon: document.getElementById('desktopSidebarClosedIcon'),
       githubReleaseVersion: document.getElementById('githubReleaseVersion'),
+      viewModeSwitch: document.getElementById('viewModeSwitch'),
+      gridViewButton: document.getElementById('gridViewButton'),
+      listViewButton: document.getElementById('listViewButton'),
     };
 
     function t(key) {
@@ -411,6 +431,8 @@
         rerenderCurrentBookmarksView();
       }
       DOM.searchInput.placeholder = t('searchPlaceholder');
+      DOM.gridViewButton.title = t('gridView');
+      DOM.listViewButton.title = t('listView');
       renderTagFilters();
       performSearch();
     }
@@ -624,16 +646,18 @@
 
     function createCard(title, url, icon, tags = []) {
       const wrap = document.createElement('div');
-      wrap.className = 'card-wrap';
+      wrap.className = `card-wrap ${appState.viewMode === 'list' ? 'card-wrap-list' : ''}`;
 
       const card = document.createElement('div');
-      card.className = 'bookmark-card card-unified cursor-pointer flex items-start transition-all p-4 bg-white shadow-sm ring-1 ring-slate-200/70 dark:pintree-ring-gray-800 rounded-2xl dark:pintree-bg-gray-900 dark:hover:pintree-bg-gray-800';
+      card.className = `bookmark-card card-unified cursor-pointer transition-all bg-white shadow-sm ring-1 ring-slate-200/70 dark:pintree-ring-gray-800 rounded-2xl dark:pintree-bg-gray-900 dark:hover:pintree-bg-gray-800 ${appState.viewMode === 'list'
+        ? 'bookmark-card-list p-2 flex items-center'
+        : 'p-4 flex items-start'}`;
       card.onclick = () => window.open(url, '_blank', 'noopener,noreferrer');
 
       const cardIcon = document.createElement('img');
       cardIcon.src = getIconUrl(url, icon);
       cardIcon.alt = title;
-      cardIcon.className = 'w-10 h-10 mr-4 rounded-xl flex-shrink-0 card-icon-bg p-1';
+      cardIcon.className = `${appState.viewMode === 'list' ? 'w-8 h-8 mr-3 rounded-lg' : 'w-10 h-10 mr-4 rounded-xl'} flex-shrink-0 card-icon-bg p-1`;
       cardIcon.onerror = () => {
         if (cardIcon.dataset.fallbackApplied) {
           cardIcon.src = 'assets/default-icon.svg';
@@ -647,17 +671,17 @@
       cardContent.className = 'flex flex-col overflow-hidden w-full';
 
       const cardTitle = document.createElement('h2');
-      cardTitle.className = 'text-sm font-semibold mb-1 text-slate-700 dark:text-slate-300 truncate';
+      cardTitle.className = `${appState.viewMode === 'list' ? 'text-xs' : 'text-sm mb-1'} font-semibold text-slate-700 dark:text-slate-300 truncate`;
       cardTitle.innerText = title;
 
       const cleanUrl = cleanDisplayUrl(url || '');
       const cardUrl = document.createElement('p');
-      cardUrl.className = 'text-xs text-slate-400 dark:text-slate-500 truncate';
+      cardUrl.className = `${appState.viewMode === 'list' ? 'text-[11px]' : 'text-xs'} text-slate-400 dark:text-slate-500 truncate`;
       cardUrl.innerText = cleanUrl;
 
       const tagWrap = document.createElement('div');
-      tagWrap.className = 'flex flex-wrap gap-1 mt-2';
-      tags.slice(0, 4).forEach(tag => {
+      tagWrap.className = `flex flex-wrap gap-1 ${appState.viewMode === 'list' ? 'mt-1' : 'mt-2'}`;
+      tags.slice(0, appState.viewMode === 'list' ? 3 : 4).forEach(tag => {
         const chip = document.createElement('button');
         chip.type = 'button';
         chip.className = 'mini-chip';
@@ -689,10 +713,12 @@
 
     function createFolderCard(title, children, path, tags = []) {
       const wrap = document.createElement('div');
-      wrap.className = 'card-wrap';
+      wrap.className = `card-wrap ${appState.viewMode === 'list' ? 'card-wrap-list' : ''}`;
 
       const card = document.createElement('div');
-      card.className = 'folder-card card-unified text-gray rounded-2xl cursor-pointer flex flex-col items-center p-2';
+      card.className = `folder-card card-unified text-gray rounded-2xl cursor-pointer ${appState.viewMode === 'list'
+        ? 'folder-card-list flex items-center p-2'
+        : 'flex flex-col items-center p-2'}`;
       card.onclick = () => {
         const newPath = path.concat({ title, children });
         appState.query = '';
@@ -712,7 +738,7 @@
       `;
 
       const cardTitle = document.createElement('h2');
-      cardTitle.className = 'text-xs font-medium text-center w-full truncate dark:text-gray-400';
+      cardTitle.className = `text-xs font-medium ${appState.viewMode === 'list' ? 'text-left pl-2' : 'text-center'} w-full truncate dark:text-gray-400`;
       cardTitle.innerText = title;
 
       card.append(cardIcon, cardTitle);
@@ -867,17 +893,29 @@
 
       if (folders.length) {
         const folderSection = document.createElement('div');
-        folderSection.className = 'grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-4 2xl:grid-cols-5 gap-4';
+        folderSection.className = appState.viewMode === 'list'
+          ? 'grid grid-cols-1 lg:grid-cols-2 xl:grid-cols-3 gap-2'
+          : 'grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-4 2xl:grid-cols-5 gap-4';
         folders.forEach(folder => folderSection.appendChild(createFolderCard(folder.title, folder.children, path, folder.__resolvedTags || getItemTags(folder))));
         DOM.bookmarks.appendChild(folderSection);
       }
 
       if (links.length) {
         const linkSection = document.createElement('div');
-        linkSection.className = 'grid grid-cols-2 sm:grid-cols-3 xl:grid-cols-4 2xl:grid-cols-5 gap-4';
+        linkSection.className = appState.viewMode === 'list'
+          ? 'grid grid-cols-1 lg:grid-cols-2 xl:grid-cols-3 gap-2'
+          : 'grid grid-cols-2 sm:grid-cols-3 xl:grid-cols-4 2xl:grid-cols-5 gap-4';
         links.forEach(link => linkSection.appendChild(createCard(link.title, link.url, link.icon, link.__resolvedTags || getItemTags(link))));
         DOM.bookmarks.appendChild(linkSection);
       }
+    }
+
+    function applyViewMode(mode) {
+      appState.viewMode = mode === 'list' ? 'list' : 'grid';
+      localStorage.setItem('tblu-view-mode', appState.viewMode);
+      DOM.gridViewButton.classList.toggle('is-active', appState.viewMode === 'grid');
+      DOM.listViewButton.classList.toggle('is-active', appState.viewMode === 'list');
+      rerenderCurrentBookmarksView();
     }
 
     function performSearch() {
@@ -1063,6 +1101,9 @@
       toggleAnimatedMenu(DOM.searchTagPopup);
     });
 
+    DOM.gridViewButton.addEventListener('click', () => applyViewMode('grid'));
+    DOM.listViewButton.addEventListener('click', () => applyViewMode('list'));
+
     DOM.languageToggleButton.addEventListener('click', () => {
       toggleAnimatedMenu(DOM.languageMenu);
       DOM.themeMenu.classList.add('hidden');
@@ -1108,6 +1149,7 @@
     });
     applyThemeMode(appState.themeMode);
     applyDesktopSidebarState();
+    applyViewMode(appState.viewMode);
     applyLocale();
     fetchGithubReleaseVersion();
 

--- a/index.html
+++ b/index.html
@@ -153,18 +153,6 @@
                   clip-rule="evenodd"></path>
               </svg>
             </button>
-            <div id="viewModeSwitch" class="view-switch-pill" role="group" aria-label="View mode switch">
-              <button id="gridViewButton" class="view-switch-btn is-active" type="button" title="Grid view">
-                <svg class="h-4 w-4" viewBox="0 0 24 24" fill="none" stroke="currentColor">
-                  <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M4 4h6v6H4V4Zm10 0h6v6h-6V4ZM4 14h6v6H4v-6Zm10 0h6v6h-6v-6Z"></path>
-                </svg>
-              </button>
-              <button id="listViewButton" class="view-switch-btn" type="button" title="List view">
-                <svg class="h-4 w-4" viewBox="0 0 24 24" fill="none" stroke="currentColor">
-                  <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M4 7h16M4 12h16M4 17h16"></path>
-                </svg>
-              </button>
-            </div>
           </div>
           <div class="relative flex items-center gap-2">
             <div class="relative">
@@ -213,9 +201,22 @@
         <div id="loading-spinner" class="flex justify-center items-center h-full">
           <div class="loader ease-linear rounded-full border-2 border-t-2 border-gray-400 h-6 w-6"></div>
         </div>
-        <div id="breadcrumbs" class="mt-2 px-6 lg:px-8 text-sm text-gray-400 flex justify-between items-center">
-          <div id="breadcrumbs-path" class="">
-            <!-- Breadcrumbs will be inserted here -->
+        <div id="breadcrumbs" class="mt-2 px-6 lg:px-8 text-sm text-gray-400 flex justify-between items-center gap-3">
+          <div id="breadcrumbs-path" class="relative flex items-center gap-1 min-w-0 flex-1 whitespace-nowrap overflow-hidden">
+            <!-- Breadcrumbs / collapse menu will be inserted here -->
+            <div id="breadcrumbCollapseMenu" class="menu-panel hidden min-w-[180px]"></div>
+          </div>
+          <div id="viewModeSwitch" class="view-switch-pill shrink-0" role="group" aria-label="View mode switch">
+            <button id="gridViewButton" class="view-switch-btn is-active" type="button" title="Grid view">
+              <svg class="h-4 w-4" viewBox="0 0 24 24" fill="none" stroke="currentColor">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M4 4h6v6H4V4Zm10 0h6v6h-6V4ZM4 14h6v6H4v-6Zm10 0h6v6h-6v-6Z"></path>
+              </svg>
+            </button>
+            <button id="listViewButton" class="view-switch-btn" type="button" title="List view">
+              <svg class="h-4 w-4" viewBox="0 0 24 24" fill="none" stroke="currentColor">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M4 7h16M4 12h16M4 17h16"></path>
+              </svg>
+            </button>
           </div>
         </div>
         <section id="folderTagSection" class="px-6 lg:px-8 mt-2 hidden">
@@ -397,6 +398,7 @@
       searchTagFilters: document.getElementById('searchTagFilters'),
       bookmarks: document.getElementById('bookmarks'),
       breadcrumbsPath: document.getElementById('breadcrumbs-path'),
+      breadcrumbCollapseMenu: document.getElementById('breadcrumbCollapseMenu'),
       folderTagSection: document.getElementById('folderTagSection'),
       folderTags: document.getElementById('folderTags'),
       loadingSpinner: document.getElementById('loading-spinner'),
@@ -797,23 +799,64 @@
       });
     }
 
-    function renderBreadcrumbs(path) {
+    function renderCollapsedBreadcrumbMenu(collapsedItems, fullPath) {
+      DOM.breadcrumbCollapseMenu.innerHTML = '';
+      collapsedItems.forEach((item, index) => {
+        const option = document.createElement('button');
+        option.type = 'button';
+        option.className = 'menu-item';
+        option.textContent = item.title;
+        option.addEventListener('click', () => {
+          const newPath = fullPath.slice(0, index + 1);
+          renderBookmarks(item.children || [], newPath);
+          DOM.breadcrumbCollapseMenu.classList.add('hidden');
+        });
+        DOM.breadcrumbCollapseMenu.appendChild(option);
+      });
+    }
+
+    function renderBreadcrumbs(path, collapseCount = 0) {
       DOM.breadcrumbsPath.innerHTML = '';
-      path.forEach((item, index) => {
+      const clippedPath = path.slice(collapseCount);
+      if (collapseCount > 0) {
+        const collapsedItems = path.slice(0, collapseCount);
+        const ellipsis = document.createElement('button');
+        ellipsis.type = 'button';
+        ellipsis.className = 'mini-chip leading-none px-2';
+        ellipsis.textContent = '···';
+        ellipsis.addEventListener('click', (event) => {
+          event.stopPropagation();
+          renderCollapsedBreadcrumbMenu(collapsedItems, path);
+          toggleAnimatedMenu(DOM.breadcrumbCollapseMenu);
+        });
+        DOM.breadcrumbsPath.appendChild(ellipsis);
+        if (clippedPath.length) {
+          const sep = document.createElement('span');
+          sep.innerText = ' > ';
+          DOM.breadcrumbsPath.appendChild(sep);
+        }
+      }
+      clippedPath.forEach((item, index) => {
+        const actualIndex = index + collapseCount;
         const breadcrumb = document.createElement('span');
-        breadcrumb.className = 'cursor-pointer hover:underline';
+        breadcrumb.className = 'cursor-pointer hover:underline truncate max-w-[220px]';
         breadcrumb.innerText = item.title;
         breadcrumb.onclick = () => {
-          const newPath = path.slice(0, index + 1);
+          const newPath = path.slice(0, actualIndex + 1);
           renderBookmarks(item.children || [], newPath);
         };
         DOM.breadcrumbsPath.appendChild(breadcrumb);
-        if (index < path.length - 1) {
+        if (index < clippedPath.length - 1) {
           const sep = document.createElement('span');
           sep.innerText = ' > ';
           DOM.breadcrumbsPath.appendChild(sep);
         }
       });
+
+      DOM.breadcrumbsPath.appendChild(DOM.breadcrumbCollapseMenu);
+      if (DOM.breadcrumbsPath.scrollWidth > DOM.breadcrumbsPath.clientWidth && collapseCount < path.length) {
+        renderBreadcrumbs(path, collapseCount + 1);
+      }
     }
 
     function showNoResultsMessage() {
@@ -1142,10 +1185,16 @@
       if (!DOM.searchTagFilterButton.contains(e.target) && !DOM.searchTagPopup.contains(e.target)) {
         DOM.searchTagPopup.classList.add('hidden');
       }
+      if (!DOM.breadcrumbsPath.contains(e.target) && !DOM.breadcrumbCollapseMenu.contains(e.target)) {
+        DOM.breadcrumbCollapseMenu.classList.add('hidden');
+      }
     });
 
     window.matchMedia('(prefers-color-scheme: dark)').addEventListener('change', () => {
       if (appState.themeMode === 'system') applyThemeMode('system');
+    });
+    window.addEventListener('resize', () => {
+      if (appState.activePath?.length) renderBreadcrumbs(appState.activePath);
     });
     applyThemeMode(appState.themeMode);
     applyDesktopSidebarState();

--- a/index.html
+++ b/index.html
@@ -135,21 +135,18 @@
         <div class="h-full items-center flex flex-1 gap-x-4 self-stretch lg:gap-x-6 justify-between">
           <div class="flex gap-x-3 justify-between items-center">
             <img class="pl-2 h-8 w-auto lg:hidden" src="assets/logo.svg" alt="Pintree">
-            <button id="toggle-desktop-sidebar-button" class="hidden lg:flex items-center justify-center w-9 h-9 icon-action-btn" aria-label="Toggle desktop sidebar">
-              <svg id="desktopSidebarOpenIcon" class="h-5 w-5" viewBox="0 0 24 24" fill="none" stroke="currentColor">
+            <button id="sidebar-toggle-button" class="flex items-center justify-center w-9 h-9 icon-action-btn" aria-label="Toggle sidebar" title="Toggle sidebar">
+              <svg id="mobileSidebarIcon" class="h-5 w-5 lg:hidden" viewBox="0 0 1024 1024" width="20" height="20" fill="currentColor">
+                <path d="M85.333333 512a42.666667 42.666667 0 0 1 42.666667-42.666667h768a42.666667 42.666667 0 0 1 0 85.333334h-768A42.666667 42.666667 0 0 1 85.333333 512zM85.333333 256a42.666667 42.666667 0 0 1 42.666667-42.666667h768a42.666667 42.666667 0 0 1 0 85.333334h-768A42.666667 42.666667 0 0 1 85.333333 256zM85.333333 768a42.666667 42.666667 0 0 1 42.666667-42.666667h768a42.666667 42.666667 0 0 1 0 85.333334h-768A42.666667 42.666667 0 0 1 85.333333 768z"></path>
+              </svg>
+              <svg id="desktopSidebarOpenIcon" class="h-5 w-5 hidden lg:block" viewBox="0 0 24 24" fill="none" stroke="currentColor">
                 <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M15 19l-7-7 7-7"></path>
               </svg>
-              <svg id="desktopSidebarClosedIcon" class="h-5 w-5 hidden" viewBox="0 0 24 24" fill="none" stroke="currentColor">
+              <svg id="desktopSidebarClosedIcon" class="h-5 w-5 hidden lg:hidden" viewBox="0 0 24 24" fill="none" stroke="currentColor">
                 <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M9 5l7 7-7 7"></path>
               </svg>
             </button>
-            <button id="open-sidebar-button" class="lg:hidden flex items-center justify-center w-9 h-9">
-              <span class="sr-only">Open sidebar</span>
-              <svg class="h-5 w-5 text-gray-400" viewBox="0 0 1024 1024" width="20" height="20" fill="currentColor">
-                <path d="M85.333333 512a42.666667 42.666667 0 0 1 42.666667-42.666667h768a42.666667 42.666667 0 0 1 0 85.333334h-768A42.666667 42.666667 0 0 1 85.333333 512zM85.333333 256a42.666667 42.666667 0 0 1 42.666667-42.666667h768a42.666667 42.666667 0 0 1 0 85.333334h-768A42.666667 42.666667 0 0 1 85.333333 256zM85.333333 768a42.666667 42.666667 0 0 1 42.666667-42.666667h768a42.666667 42.666667 0 0 1 0 85.333334h-768A42.666667 42.666667 0 0 1 85.333333 768z"></path>
-              </svg>
-            </button>
-            <button id="openSearchModalButton" class="icon-action-btn" aria-label="Search">
+            <button id="openSearchModalButton" class="icon-action-btn" aria-label="Search" title="Search bookmarks">
               <svg class="h-5 w-5" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
                 <path fill-rule="evenodd"
                   d="M9 3.5a5.5 5.5 0 100 11 5.5 5.5 0 000-11zM2 9a7 7 0 1112.452 4.391l3.328 3.329a.75.75 0 11-1.06 1.06l-3.329-3.328A7 7 0 012 9z"
@@ -159,7 +156,7 @@
           </div>
           <div class="relative flex items-center gap-2">
             <div class="relative">
-              <button id="languageToggleButton" type="button" aria-label="Switch language" class="icon-action-btn">
+              <button id="languageToggleButton" type="button" aria-label="Switch language" class="icon-action-btn" title="Switch language">
                 <svg fill="none" viewBox="0 0 24 24" class="h-5 w-5 stroke-zinc-500" stroke-width="1.5" xmlns="http://www.w3.org/2000/svg">
                   <path d="M2 12C2 17.5228 6.47715 22 12 22C17.5228 22 22 17.5228 22 12C22 6.47715 17.5228 2 12 2C6.47715 2 2 6.47715 2 12Z" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round"/>
                   <path d="M13 2.04932C13 2.04932 16 5.99994 16 11.9999C16 17.9999 13 21.9506 13 21.9506" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round"/>
@@ -174,19 +171,19 @@
               </div>
             </div>
             <div class="relative">
-              <button id="themeToggleButton" type="button" aria-label="Switch theme" class="icon-action-btn">
+              <button id="themeToggleButton" type="button" aria-label="Switch theme" class="icon-action-btn" title="Switch theme">
                 <svg id="sunIcon" viewBox="0 0 24 24" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"
                   aria-hidden="true"
                   class="h-5 w-5 fill-zinc-100 stroke-zinc-500 dark:hidden">
-                  <path d="M8 12.25A4.25 4.25 0 0 1 12.25 8v0a4.25 4.25 0 0 1 4.25 4.25v0a4.25 4.25 0 0 1-4.25 4.25v0A4.25 4.25 0 0 1 8 12.25v0Z"></path>
+                  <path stroke="CurrentColor" d="M8 12.25A4.25 4.25 0 0 1 12.25 8v0a4.25 4.25 0 0 1 4.25 4.25v0a4.25 4.25 0 0 1-4.25 4.25v0A4.25 4.25 0 0 1 8 12.25v0Z"></path>
                   <path d="M12.25 3v1.5M21.5 12.25H20M18.791 18.791l-1.06-1.06M18.791 5.709l-1.06 1.06M12.25 20v1.5M4.5 12.25H3M6.77 6.77 5.709 5.709M6.77 17.73l-1.061 1.061"
-                    fill="none"></path>
+                    fill="none" stroke="CurrentColor"></path>
                 </svg>
                 <svg id="moonIcon" viewBox="0 0 24 24" aria-hidden="true"
                   class="hidden h-5 w-5 fill-zinc-700 stroke-zinc-500 dark:block">
                   <path
                     d="M17.25 16.22a6.937 6.937 0 0 1-9.47-9.47 7.451 7.451 0 1 0 9.47 9.47ZM12.75 7C17 7 17 2.75 17 2.75S17 7 21.25 7C17 7 17 11.25 17 11.25S17 7 12.75 7Z"
-                    stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
+                    stroke="CurrentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
                 </svg>
               </button>
               <div id="themeMenu" class="menu-panel hidden">
@@ -297,7 +294,7 @@
           <button id="closeSearchModalButton" class="absolute right-3 top-1/2 -translate-y-1/2 text-sm text-gray-500 rounded" data-i18n="close">关闭</button>
         </div>
         <div class="relative">
-          <button id="searchTagFilterButton" class="icon-action-btn" aria-label="Filter tags">
+          <button id="searchTagFilterButton" class="icon-action-btn" aria-label="Filter tags" title="Filter by tags">
             <svg class="h-5 w-5" viewBox="0 0 24 24" fill="none" stroke="currentColor">
               <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M3 5.25h18M6 12h12m-9 6.75h6"></path>
             </svg>
@@ -366,7 +363,7 @@
     };
 
     const DOM = {
-      openSidebarButton: document.getElementById('open-sidebar-button'),
+      sidebarToggleButton: document.getElementById('sidebar-toggle-button'),
       closeSidebarButton: document.getElementById('close-sidebar-button'),
       offCanvasMenu: document.getElementById('off-canvas-menu'),
       offCanvasBackdrop: document.getElementById('off-canvas-backdrop'),
@@ -395,7 +392,6 @@
       moonIcon: document.getElementById('moonIcon'),
       desktopSidebarContainer: document.getElementById('desktopSidebarContainer'),
       mainLayout: document.getElementById('mainLayout'),
-      toggleDesktopSidebarButton: document.getElementById('toggle-desktop-sidebar-button'),
       desktopSidebarOpenIcon: document.getElementById('desktopSidebarOpenIcon'),
       desktopSidebarClosedIcon: document.getElementById('desktopSidebarClosedIcon'),
       githubReleaseVersion: document.getElementById('githubReleaseVersion'),
@@ -576,9 +572,7 @@
 
     function setTagFilter(tag) {
       if (!tag) return;
-      if (!appState.activeTags.some(item => normalize(item) === normalize(tag))) {
-        appState.activeTags.push(tag);
-      }
+      appState.activeTags = [tag];
       DOM.resetTagFilter.classList.toggle('hidden', !appState.activeTags.length);
       renderTagFilters();
       if (DOM.searchModal.classList.contains('hidden')) openSearchModal();
@@ -904,8 +898,10 @@
       DOM.desktopSidebarContainer.classList.toggle('-translate-x-full', appState.desktopSidebarCollapsed);
       DOM.mainLayout.classList.toggle('lg:pl-0', appState.desktopSidebarCollapsed);
       DOM.mainLayout.classList.toggle('lg:pl-72', !appState.desktopSidebarCollapsed);
-      DOM.desktopSidebarOpenIcon.classList.toggle('hidden', appState.desktopSidebarCollapsed);
-      DOM.desktopSidebarClosedIcon.classList.toggle('hidden', !appState.desktopSidebarCollapsed);
+      DOM.desktopSidebarOpenIcon.classList.toggle('lg:block', !appState.desktopSidebarCollapsed);
+      DOM.desktopSidebarOpenIcon.classList.toggle('lg:hidden', appState.desktopSidebarCollapsed);
+      DOM.desktopSidebarClosedIcon.classList.toggle('lg:block', appState.desktopSidebarCollapsed);
+      DOM.desktopSidebarClosedIcon.classList.toggle('lg:hidden', !appState.desktopSidebarCollapsed);
       localStorage.setItem('tblu-desktop-sidebar-collapsed', appState.desktopSidebarCollapsed ? '1' : '0');
     }
 
@@ -913,11 +909,15 @@
       if (!DOM.githubReleaseVersion) return;
       try {
         const response = await fetch('https://api.github.com/repos/TonyBlur/tblu-bookmark/releases/latest');
+        if (response.status === 404) {
+          DOM.githubReleaseVersion.textContent = 'unknown';
+          return;
+        }
         if (!response.ok) throw new Error(`HTTP ${response.status}`);
         const data = await response.json();
-        DOM.githubReleaseVersion.textContent = data.tag_name || data.name || 'No release';
+        DOM.githubReleaseVersion.textContent = data.tag_name || 'unknown';
       } catch (error) {
-        DOM.githubReleaseVersion.textContent = 'No release';
+        DOM.githubReleaseVersion.textContent = 'unknown';
       }
     }
 
@@ -1011,7 +1011,12 @@
       shouldDark ? applyDarkTheme() : applyLightTheme();
     }
 
-    DOM.openSidebarButton.addEventListener('click', () => {
+    DOM.sidebarToggleButton.addEventListener('click', () => {
+      if (window.innerWidth >= 1024) {
+        appState.desktopSidebarCollapsed = !appState.desktopSidebarCollapsed;
+        applyDesktopSidebarState();
+        return;
+      }
       DOM.offCanvasMenu.classList.remove('hidden');
       setTimeout(() => {
         DOM.offCanvasBackdrop.classList.add('opacity-100');
@@ -1051,11 +1056,6 @@
       DOM.resetTagFilter.classList.add('hidden');
       renderTagFilters();
       performSearch();
-    });
-
-    DOM.toggleDesktopSidebarButton.addEventListener('click', () => {
-      appState.desktopSidebarCollapsed = !appState.desktopSidebarCollapsed;
-      applyDesktopSidebarState();
     });
 
     DOM.searchTagFilterButton.addEventListener('click', (e) => {

--- a/index.html
+++ b/index.html
@@ -353,6 +353,13 @@
         themeSystem: '跟随系统',
         themeLight: '浅色',
         themeDark: '深色',
+        toggleSidebar: '切换侧边栏',
+        searchButton: '搜索书签',
+        switchLanguage: '切换语言',
+        switchTheme: '切换主题',
+        filterTagsButton: '按标签筛选',
+        backToTop: '回到顶部',
+        closeSidebar: '关闭侧边栏',
       },
       en: {
         clear: 'Clear',
@@ -373,6 +380,13 @@
         themeSystem: 'System',
         themeLight: 'Light',
         themeDark: 'Dark',
+        toggleSidebar: 'Toggle sidebar',
+        searchButton: 'Search bookmarks',
+        switchLanguage: 'Switch language',
+        switchTheme: 'Switch theme',
+        filterTagsButton: 'Filter by tags',
+        backToTop: 'Back to top',
+        closeSidebar: 'Close sidebar',
       }
     };
 
@@ -427,6 +441,7 @@
       gridViewButton: document.getElementById('gridViewButton'),
       listViewButton: document.getElementById('listViewButton'),
       backToTopButton: document.getElementById('backToTopButton'),
+      closeSidebarSrOnly: document.querySelector('#close-sidebar-button .sr-only'),
     };
 
     function t(key) {
@@ -445,6 +460,19 @@
       DOM.searchInput.placeholder = t('searchPlaceholder');
       DOM.gridViewButton.title = t('gridView');
       DOM.listViewButton.title = t('listView');
+      DOM.sidebarToggleButton.title = t('toggleSidebar');
+      DOM.sidebarToggleButton.setAttribute('aria-label', t('toggleSidebar'));
+      DOM.openSearchModalButton.title = t('searchButton');
+      DOM.openSearchModalButton.setAttribute('aria-label', t('searchButton'));
+      DOM.languageToggleButton.title = t('switchLanguage');
+      DOM.languageToggleButton.setAttribute('aria-label', t('switchLanguage'));
+      DOM.themeToggleButton.title = t('switchTheme');
+      DOM.themeToggleButton.setAttribute('aria-label', t('switchTheme'));
+      DOM.searchTagFilterButton.title = t('filterTagsButton');
+      DOM.searchTagFilterButton.setAttribute('aria-label', t('filterTagsButton'));
+      DOM.backToTopButton.title = t('backToTop');
+      DOM.backToTopButton.setAttribute('aria-label', t('backToTop'));
+      if (DOM.closeSidebarSrOnly) DOM.closeSidebarSrOnly.textContent = t('closeSidebar');
       renderTagFilters();
       performSearch();
     }

--- a/index.html
+++ b/index.html
@@ -78,7 +78,7 @@
     <div id="off-canvas-menu" class="relative z-50 lg:hidden hidden" role="dialog" aria-modal="true">
       <div class="fixed inset-0 flex">
         <div id="off-canvas-backdrop"
-          class="fixed inset-0 bg-gray-900/80 opacity-0 transition-opacity ease-linear duration-300" style="backdrop-filter: blur(20px);"></div>
+          class="fixed inset-0 bg-zinc-900/55 opacity-0 transition-opacity ease-linear duration-300" style="backdrop-filter: blur(14px);"></div>
         <div id="off-canvas-content"
           class="relative mr-16 flex w-full max-w-xs flex-1 -translate-x-full transition ease-in-out duration-300 transform">
           <!-- Close button for the off-canvas menu -->
@@ -131,7 +131,7 @@
     <!-- Main Content Area -->
     <div id="mainLayout" class="lg:pl-72 dark:pintree-bg-gray-900 flex flex-col min-h-screen transition-all duration-300 ease-in-out">
       <div
-        class="items-center justify-between sticky top-0 z-40 flex h-16 shrink-0 gap-x-4 border-b border-slate-200/70 dark:pintree-border-gray-800 bg-white/85 dark:bg-slate-900/80 px-4 shadow-sm backdrop-blur sm:gap-x-6 sm:px-6 lg:px-8">
+        class="items-center justify-between sticky top-0 z-40 flex h-16 shrink-0 gap-x-4 border-b border-slate-200/70 dark:pintree-border-gray-800 bg-white/85 dark:bg-zinc-900/80 px-4 shadow-sm backdrop-blur sm:gap-x-6 sm:px-6 lg:px-8">
         <div class="h-full items-center flex flex-1 gap-x-4 self-stretch lg:gap-x-6 justify-between">
           <div class="flex gap-x-3 justify-between items-center">
             <img class="pl-2 h-8 w-auto lg:hidden" src="assets/logo.svg" alt="Pintree">
@@ -290,6 +290,15 @@
     </div>
   </div>
 
+  <button id="backToTopButton"
+    class="fixed bottom-6 right-6 z-50 hidden icon-action-btn"
+    aria-label="Back to top"
+    title="Back to top">
+    <svg class="h-5 w-5" viewBox="0 0 24 24" fill="none" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M5 10l7-7 7 7M12 3v18"></path>
+    </svg>
+  </button>
+
   <div id="searchModal" class="fixed inset-0 z-[60] hidden items-start justify-center bg-slate-900/40 p-4 pt-20 backdrop-blur-sm">
     <div class="panel-card w-full max-w-2xl p-4">
       <div class="flex items-center gap-2 mb-3">
@@ -417,6 +426,7 @@
       viewModeSwitch: document.getElementById('viewModeSwitch'),
       gridViewButton: document.getElementById('gridViewButton'),
       listViewButton: document.getElementById('listViewButton'),
+      backToTopButton: document.getElementById('backToTopButton'),
     };
 
     function t(key) {
@@ -651,7 +661,7 @@
       wrap.className = `card-wrap ${appState.viewMode === 'list' ? 'card-wrap-list' : ''}`;
 
       const card = document.createElement('div');
-      card.className = `bookmark-card card-unified cursor-pointer bg-white ring-1 ring-slate-200/70 dark:pintree-ring-gray-800 rounded-2xl dark:pintree-bg-gray-900 dark:hover:pintree-bg-gray-800 ${appState.viewMode === 'list'
+      card.className = `bookmark-card card-unified cursor-pointer bg-white ring-1 ring-slate-200/70 dark:ring-slate-800/90 rounded-2xl dark:pintree-bg-gray-900 dark:hover:pintree-bg-gray-800 ${appState.viewMode === 'list'
         ? 'bookmark-card-list p-2 flex items-center'
         : 'p-4 flex items-start'}`;
       card.onclick = () => window.open(url, '_blank', 'noopener,noreferrer');
@@ -718,7 +728,7 @@
       wrap.className = `card-wrap ${appState.viewMode === 'list' ? 'card-wrap-list' : ''}`;
 
       const card = document.createElement('div');
-      card.className = `folder-card card-unified text-gray rounded-2xl cursor-pointer ring-1 ring-slate-200/70 dark:pintree-ring-gray-800 dark:pintree-bg-gray-900 dark:hover:pintree-bg-gray-800 ${appState.viewMode === 'list'
+      card.className = `folder-card card-unified text-gray rounded-2xl cursor-pointer dark:pintree-bg-gray-900 dark:hover:pintree-bg-gray-800 ${appState.viewMode === 'list'
         ? 'folder-card-list flex items-center p-2'
         : 'flex flex-col items-center p-2'}`;
       card.onclick = () => {
@@ -799,15 +809,15 @@
       });
     }
 
-    function renderCollapsedBreadcrumbMenu(collapsedItems, fullPath) {
+    function renderCollapsedBreadcrumbMenu(ancestorsPath) {
       DOM.breadcrumbCollapseMenu.innerHTML = '';
-      collapsedItems.forEach((item, index) => {
+      ancestorsPath.forEach((item, index) => {
         const option = document.createElement('button');
         option.type = 'button';
         option.className = 'menu-item';
         option.textContent = item.title;
         option.addEventListener('click', () => {
-          const newPath = fullPath.slice(0, index + 1);
+          const newPath = ancestorsPath.slice(0, index + 1);
           renderBookmarks(item.children || [], newPath);
           DOM.breadcrumbCollapseMenu.classList.add('hidden');
         });
@@ -819,14 +829,14 @@
       DOM.breadcrumbsPath.innerHTML = '';
       const clippedPath = path.slice(collapseCount);
       if (collapseCount > 0) {
-        const collapsedItems = path.slice(0, collapseCount);
+        const ancestorsPath = path.slice(0, Math.max(path.length - 1, 0));
         const ellipsis = document.createElement('button');
         ellipsis.type = 'button';
         ellipsis.className = 'mini-chip leading-none px-2';
         ellipsis.textContent = '···';
         ellipsis.addEventListener('click', (event) => {
           event.stopPropagation();
-          renderCollapsedBreadcrumbMenu(collapsedItems, path);
+          renderCollapsedBreadcrumbMenu(ancestorsPath);
           toggleAnimatedMenu(DOM.breadcrumbCollapseMenu);
         });
         DOM.breadcrumbsPath.appendChild(ellipsis);
@@ -958,7 +968,15 @@
       localStorage.setItem('tblu-view-mode', appState.viewMode);
       DOM.gridViewButton.classList.toggle('is-active', appState.viewMode === 'grid');
       DOM.listViewButton.classList.toggle('is-active', appState.viewMode === 'list');
-      rerenderCurrentBookmarksView();
+      DOM.bookmarks.classList.add('view-transitioning');
+      requestAnimationFrame(() => {
+        rerenderCurrentBookmarksView();
+        setTimeout(() => DOM.bookmarks.classList.remove('view-transitioning'), 220);
+      });
+    }
+
+    function setBodyScrollLock(locked) {
+      document.body.classList.toggle('overflow-hidden', locked);
     }
 
     function performSearch() {
@@ -1005,6 +1023,7 @@
     function closeSidebar() {
       DOM.offCanvasBackdrop.classList.remove('opacity-100');
       DOM.offCanvasContent.classList.remove('translate-x-0');
+      setBodyScrollLock(false);
       setTimeout(() => DOM.offCanvasMenu.classList.add('hidden'), 300);
     }
 
@@ -1099,6 +1118,7 @@
         return;
       }
       DOM.offCanvasMenu.classList.remove('hidden');
+      setBodyScrollLock(true);
       setTimeout(() => {
         DOM.offCanvasBackdrop.classList.add('opacity-100');
         DOM.offCanvasContent.classList.add('translate-x-0');
@@ -1146,6 +1166,7 @@
 
     DOM.gridViewButton.addEventListener('click', () => applyViewMode('grid'));
     DOM.listViewButton.addEventListener('click', () => applyViewMode('list'));
+    DOM.backToTopButton.addEventListener('click', () => window.scrollTo({ top: 0, behavior: 'smooth' }));
 
     DOM.languageToggleButton.addEventListener('click', () => {
       toggleAnimatedMenu(DOM.languageMenu);
@@ -1195,6 +1216,9 @@
     });
     window.addEventListener('resize', () => {
       if (appState.activePath?.length) renderBreadcrumbs(appState.activePath);
+    });
+    window.addEventListener('scroll', () => {
+      DOM.backToTopButton.classList.toggle('hidden', window.scrollY < 280);
     });
     applyThemeMode(appState.themeMode);
     applyDesktopSidebarState();

--- a/index.html
+++ b/index.html
@@ -651,7 +651,7 @@
       wrap.className = `card-wrap ${appState.viewMode === 'list' ? 'card-wrap-list' : ''}`;
 
       const card = document.createElement('div');
-      card.className = `bookmark-card card-unified cursor-pointer transition-all bg-white shadow-sm ring-1 ring-slate-200/70 dark:pintree-ring-gray-800 rounded-2xl dark:pintree-bg-gray-900 dark:hover:pintree-bg-gray-800 ${appState.viewMode === 'list'
+      card.className = `bookmark-card card-unified cursor-pointer bg-white shadow-sm ring-1 ring-slate-200/70 dark:pintree-ring-gray-800 rounded-2xl dark:pintree-bg-gray-900 dark:hover:pintree-bg-gray-800 ${appState.viewMode === 'list'
         ? 'bookmark-card-list p-2 flex items-center'
         : 'p-4 flex items-start'}`;
       card.onclick = () => window.open(url, '_blank', 'noopener,noreferrer');
@@ -839,7 +839,7 @@
       clippedPath.forEach((item, index) => {
         const actualIndex = index + collapseCount;
         const breadcrumb = document.createElement('span');
-        breadcrumb.className = 'cursor-pointer hover:underline truncate max-w-[220px]';
+        breadcrumb.className = 'cursor-pointer hover:underline shrink-0';
         breadcrumb.innerText = item.title;
         breadcrumb.onclick = () => {
           const newPath = path.slice(0, actualIndex + 1);

--- a/index.html
+++ b/index.html
@@ -661,7 +661,7 @@
       wrap.className = `card-wrap ${appState.viewMode === 'list' ? 'card-wrap-list' : ''}`;
 
       const card = document.createElement('div');
-      card.className = `bookmark-card card-unified cursor-pointer bg-white ring-1 ring-slate-200/70 hover:ring-slate-200/70 dark:ring-slate-800/90 dark:hover:ring-slate-800/90 rounded-2xl dark:pintree-bg-gray-900 dark:hover:pintree-bg-gray-800 ${appState.viewMode === 'list'
+      card.className = `bookmark-card card-unified cursor-pointer bg-white border border-slate-200/70 dark:border-slate-800/90 rounded-2xl dark:pintree-bg-gray-900 dark:hover:pintree-bg-gray-800 ${appState.viewMode === 'list'
         ? 'bookmark-card-list p-2 flex items-center'
         : 'p-4 flex items-start'}`;
       card.onclick = () => window.open(url, '_blank', 'noopener,noreferrer');
@@ -980,7 +980,8 @@
     }
 
     function updateBackToTopVisibility() {
-      DOM.backToTopButton.classList.toggle('hidden', window.scrollY < 280);
+      const y = Math.max(window.scrollY || 0, document.documentElement.scrollTop || 0);
+      DOM.backToTopButton.classList.toggle('hidden', y <= 8 || y < 280);
     }
 
     function performSearch() {


### PR DESCRIPTION
### Motivation
- Surface repository status and make it easy for users to jump to the GitHub repo and see the latest release in the footer.  
- Allow richer tag-based discovery by enabling selecting multiple tags and making tag chips interactive.  
- Improve desktop UX by allowing the sidebar to be collapsed and persisted between sessions.

### Description
- Modified `index.html` to add a GitHub link + release badge in the footer and implemented `fetchGithubReleaseVersion()` to fetch `/repos/TonyBlur/tblu-bookmark/releases/latest` and show `tag_name` with a fallback.  
- Replaced single `activeTag` state with `activeTags` (array) and updated search flow to accept multiple tags with AND-style matching in `searchInFlattenedData()` and related call sites.  
- Made tag chips on bookmark cards and folder tags clickable; clicking a tag applies it to `activeTags`, opens the search modal (if closed), and updates filters via `setTagFilter()`.  
- Added a collapsible desktop sidebar: new elements `desktopSidebarContainer` and `toggle-desktop-sidebar-button`, persisted state via `localStorage` (`tblu-desktop-sidebar-collapsed`), and `applyDesktopSidebarState()` to update layout classes and icon states.

### Testing
- Ran the static build with `npm run build`, which completed successfully.  
- No automated unit tests exist in the repo; changes were validated by building the CSS and ensuring no runtime build errors occurred during `npm run build`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ca68f7039c832c8b940699cccb2ad6)