### PR TITLE
feat: improve desktop grid density, favicon fallback reliability, and search result actions

### DIFF
--- a/index.html
+++ b/index.html
@@ -52,6 +52,27 @@
 
   <!-- Stylesheet -->
   <link rel="stylesheet" href="css/tailwind.css">
+  <style>
+    .folder-grid-auto {
+      grid-template-columns: repeat(auto-fill, minmax(180px, 1fr));
+    }
+    .bookmark-grid-auto {
+      grid-template-columns: repeat(auto-fill, minmax(230px, 1fr));
+    }
+    .bookmark-highlight {
+      animation: bookmarkPulse 3s ease;
+      box-shadow: 0 0 0 2px rgba(56, 189, 248, 0.85);
+      border-radius: 1rem;
+    }
+    @keyframes bookmarkPulse {
+      0%, 100% { background: transparent; }
+      20%, 80% { background: rgba(186, 230, 253, 0.42); }
+    }
+    .dark .bookmark-highlight {
+      box-shadow: 0 0 0 2px rgba(125, 211, 252, 0.8);
+      background: rgba(14, 116, 144, 0.22);
+    }
+  </style>
 
   <!-- Structured Data for SEO -->
   <script type="application/ld+json">
@@ -546,7 +567,8 @@
     function flattenData(nodes, parentPath = [], inheritedTags = []) {
       const items = [];
       if (!Array.isArray(nodes)) return items;
-      nodes.forEach(node => {
+      nodes.forEach((node, index) => {
+        if (!node.__id) node.__id = `bookmark-${Date.now()}-${Math.random().toString(36).slice(2, 8)}-${index}`;
         const currentPath = parentPath.concat({ title: node.title, children: node.children || [] });
         const ownTags = getItemTags(node);
         const tags = [...new Set([...(inheritedTags || []), ...ownTags])];
@@ -668,7 +690,7 @@
       }
     }
 
-    function createCard(title, url, icon, tags = []) {
+    function createCard(title, url, icon, tags = [], bookmarkId = '') {
       const wrap = document.createElement('div');
       wrap.className = `card-wrap ${appState.viewMode === 'list' ? 'card-wrap-list' : ''}`;
 
@@ -677,18 +699,22 @@
         ? 'bookmark-card-list p-2 flex items-center'
         : 'p-4 flex items-start'}`;
       card.onclick = () => window.open(url, '_blank', 'noopener,noreferrer');
+      if (bookmarkId) card.dataset.bookmarkId = bookmarkId;
 
       const cardIcon = document.createElement('img');
-      cardIcon.src = getIconUrl(url, icon);
+      const iconCandidates = getIconCandidates(url, icon);
+      cardIcon.src = iconCandidates[0];
       cardIcon.alt = title;
       cardIcon.className = `${appState.viewMode === 'list' ? 'w-8 h-8 mr-3 rounded-lg' : 'w-10 h-10 mr-4 rounded-xl'} flex-shrink-0 card-icon-bg p-1`;
+      cardIcon.dataset.iconFallbackIndex = '0';
       cardIcon.onerror = () => {
-        if (cardIcon.dataset.fallbackApplied) {
-          cardIcon.src = 'assets/default-icon.svg';
+        const currentIndex = Number(cardIcon.dataset.iconFallbackIndex || 0) + 1;
+        cardIcon.dataset.iconFallbackIndex = String(currentIndex);
+        if (currentIndex < iconCandidates.length) {
+          cardIcon.src = iconCandidates[currentIndex];
           return;
         }
-        cardIcon.dataset.fallbackApplied = '1';
-        cardIcon.src = getIconUrl(url);
+        cardIcon.src = 'assets/default-icon.svg';
       };
 
       const cardContent = document.createElement('div');
@@ -724,14 +750,55 @@
       return wrap;
     }
 
-    function getIconUrl(url, icon) {
-      if (icon && !icon.includes('logo.clearbit.com')) return icon;
-      if (!url) return icon || 'assets/default-icon.svg';
+    function getIconCandidates(url, icon) {
+      if (!url && icon) return [icon, 'assets/default-icon.svg'];
+      if (!url) return ['assets/default-icon.svg'];
       try {
-        const hostname = new URL(url).hostname;
-        return `https://www.google.com/s2/favicons?domain=${hostname}&sz=64`;
+        const parsed = new URL(url);
+        const hostname = parsed.hostname;
+        const origin = parsed.origin;
+        const candidates = [];
+        if (icon && !icon.includes('logo.clearbit.com')) candidates.push(icon);
+        candidates.push(
+          `${origin}/favicon.ico`,
+          `${origin}/apple-touch-icon.png`,
+          `https://icons.duckduckgo.com/ip3/${hostname}.ico`,
+          `https://icon.horse/icon/${hostname}`,
+          'assets/default-icon.svg',
+        );
+        return [...new Set(candidates)];
       } catch {
-        return icon || 'assets/default-icon.svg';
+        return icon ? [icon, 'assets/default-icon.svg'] : ['assets/default-icon.svg'];
+      }
+    }
+
+    function openBookmarkInNewTab(item) {
+      if (!item || !item.url) return;
+      window.open(item.url, '_blank', 'noopener,noreferrer');
+    }
+
+    function highlightBookmarkCard(bookmarkId) {
+      if (!bookmarkId) return;
+      const target = DOM.bookmarks.querySelector(`[data-bookmark-id="${bookmarkId}"]`);
+      if (!target) return;
+      target.scrollIntoView({ behavior: 'smooth', block: 'center', inline: 'nearest' });
+      target.classList.add('bookmark-highlight');
+      setTimeout(() => target.classList.remove('bookmark-highlight'), 3000);
+    }
+
+    function revealBookmarkPath(item, options = {}) {
+      if (!item) return;
+      const targetPath = item.path || [];
+      if (item.type === 'folder') {
+        renderBookmarks(item.children || [], targetPath);
+        return;
+      }
+      const parent = targetPath[targetPath.length - 1];
+      renderBookmarks(parent?.children || [], targetPath);
+      if (options.highlightBookmark) {
+        requestAnimationFrame(() => {
+          setTimeout(() => highlightBookmarkCard(item.__id), 120);
+        });
       }
     }
 
@@ -894,7 +961,8 @@
         results,
         t,
         cleanDisplayUrl,
-        renderBookmarks,
+        openBookmarkInNewTab,
+        revealBookmarkPath,
         closeSearchModal,
       });
     }
@@ -933,7 +1001,7 @@
         const folderSection = document.createElement('div');
         folderSection.className = appState.viewMode === 'list'
           ? 'grid grid-cols-1 lg:grid-cols-2 xl:grid-cols-3 gap-2'
-          : 'grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-4 2xl:grid-cols-5 gap-4';
+          : 'grid folder-grid-auto gap-4';
         folders.forEach(folder => folderSection.appendChild(createFolderCard(folder.title, folder.children, path, folder.__resolvedTags || getItemTags(folder))));
         DOM.bookmarks.appendChild(folderSection);
       }
@@ -942,8 +1010,8 @@
         const linkSection = document.createElement('div');
         linkSection.className = appState.viewMode === 'list'
           ? 'grid grid-cols-1 lg:grid-cols-2 xl:grid-cols-3 gap-2'
-          : 'grid grid-cols-2 sm:grid-cols-3 xl:grid-cols-4 2xl:grid-cols-5 gap-4';
-        links.forEach(link => linkSection.appendChild(createCard(link.title, link.url, link.icon, link.__resolvedTags || getItemTags(link))));
+          : 'grid bookmark-grid-auto gap-4';
+        links.forEach(link => linkSection.appendChild(createCard(link.title, link.url, link.icon, link.__resolvedTags || getItemTags(link), link.__id)));
         DOM.bookmarks.appendChild(linkSection);
       }
     }

--- a/index.html
+++ b/index.html
@@ -54,7 +54,7 @@
   <link rel="stylesheet" href="css/tailwind.css">
   <style>
     .folder-grid-auto {
-      grid-template-columns: repeat(auto-fill, minmax(180px, 1fr));
+      grid-template-columns: repeat(auto-fill, minmax(132px, 1fr));
     }
     .bookmark-grid-auto {
       grid-template-columns: repeat(auto-fill, minmax(230px, 1fr));
@@ -71,6 +71,11 @@
     .dark .bookmark-highlight {
       box-shadow: 0 0 0 2px rgba(125, 211, 252, 0.8);
       background: rgba(14, 116, 144, 0.22);
+    }
+    @media (min-width: 1024px) {
+      .folder-grid-auto {
+        grid-template-columns: repeat(auto-fill, minmax(148px, 1fr));
+      }
     }
   </style>
 

--- a/index.html
+++ b/index.html
@@ -57,7 +57,7 @@
       grid-template-columns: repeat(auto-fill, minmax(132px, 1fr));
     }
     .bookmark-grid-auto {
-      grid-template-columns: repeat(auto-fill, minmax(230px, 1fr));
+      grid-template-columns: repeat(auto-fill, minmax(158px, 1fr));
     }
     .bookmark-highlight {
       animation: bookmarkPulse 3s ease;
@@ -75,6 +75,9 @@
     @media (min-width: 1024px) {
       .folder-grid-auto {
         grid-template-columns: repeat(auto-fill, minmax(148px, 1fr));
+      }
+      .bookmark-grid-auto {
+        grid-template-columns: repeat(auto-fill, minmax(210px, 1fr));
       }
     }
   </style>
@@ -511,7 +514,9 @@
 
     function deriveTagsFromRules(item) {
       if (!appState.tagRules.length) return [];
-      const text = `${item.title || ''} ${item.url || ''}`.toLowerCase();
+      if (item.type !== 'link') return [];
+      const titleText = `${item.title || ''}`.toLowerCase();
+      const urlText = `${item.url || ''}`.toLowerCase();
       let hostname = '';
       try {
         hostname = item.url ? new URL(item.url).hostname.toLowerCase() : '';
@@ -522,8 +527,18 @@
       const matched = appState.tagRules
         .filter(rule => {
           const byDomain = (rule.domains || []).some(domain => hostname === domain || hostname.endsWith(`.${domain}`));
-          const byKeyword = (rule.keywords || []).some(keyword => keywordMatch(text, String(keyword).toLowerCase()));
-          return byDomain || byKeyword;
+          if (byDomain) return true;
+          const keywordHits = (rule.keywords || []).filter(keyword => {
+            const normalizedKeyword = String(keyword).toLowerCase().trim();
+            if (!normalizedKeyword) return false;
+            const hasCJK = /[\u4e00-\u9fff]/.test(normalizedKeyword);
+            if (hasCJK) {
+              return keywordMatch(titleText, normalizedKeyword) || keywordMatch(urlText, normalizedKeyword);
+            }
+            return keywordMatch(urlText, normalizedKeyword);
+          });
+          const preciseKeywordMatch = keywordHits.length >= 2;
+          return preciseKeywordMatch;
         })
         .map(rule => getRuleTagLabel(rule))
         .filter(Boolean);

--- a/index.html
+++ b/index.html
@@ -1130,6 +1130,7 @@
       const alphaVersion = commitShort ? `alpha-${commitShort}` : '';
       const fallbackVersion = alphaVersion || stableVersion || 'unknown';
       setVersionBadge(fallbackVersion, false);
+      if (alphaVersion) return;
       try {
         const response = await fetch('https://api.github.com/repos/TonyBlur/tblu-bookmark/releases?per_page=20');
         if (!response.ok) throw new Error(`HTTP ${response.status}`);

--- a/js/components/search-ui.js
+++ b/js/components/search-ui.js
@@ -12,7 +12,8 @@ window.SearchUI = {
     results,
     t,
     cleanDisplayUrl,
-    renderBookmarks,
+    openBookmarkInNewTab,
+    revealBookmarkPath,
     closeSearchModal,
   }) {
     container.innerHTML = '';
@@ -26,29 +27,64 @@ window.SearchUI = {
 
     results.slice(0, 80).forEach(result => {
       const item = result.item;
-      const row = document.createElement('button');
-      row.className = 'w-full text-left p-3 rounded-xl hover:bg-slate-100 dark:hover:pintree-bg-gray-800';
+      const row = document.createElement('div');
+      row.className = 'group w-full text-left p-3 rounded-xl hover:bg-slate-100 dark:hover:pintree-bg-gray-800';
       const typeIcon = result.hitType === 'folder'
         ? '📁'
         : result.hitType === 'tag'
           ? '🏷️'
           : '🔗';
-      row.innerHTML = `<div class="flex items-center gap-2">
-          <span class="text-sm">${typeIcon}</span>
-          <div class="text-sm font-medium text-slate-700 dark:text-slate-300 truncate">${item.title}</div>
-        </div>
-        <div class="text-xs text-slate-400 truncate pl-6">${cleanDisplayUrl(item.url || '')}</div>`;
+      row.innerHTML = `<div class="flex items-start gap-3">
+          <button type="button" class="search-result-main flex-1 min-w-0 text-left">
+            <div class="flex items-center gap-2">
+              <span class="text-sm">${typeIcon}</span>
+              <div class="text-sm font-medium text-slate-700 dark:text-slate-300 truncate">${item.title}</div>
+            </div>
+            <div class="text-xs text-slate-400 truncate pl-6">${cleanDisplayUrl(item.url || '')}</div>
+          </button>
+          <div class="search-result-actions opacity-0 group-hover:opacity-100 group-focus-within:opacity-100 transition-opacity duration-150 flex items-center gap-1 mt-0.5"></div>
+        </div>`;
 
-      row.addEventListener('click', () => {
-        const targetPath = item.path || [];
-        if (item.type === 'folder') {
-          renderBookmarks(item.children || [], targetPath);
-        } else {
-          const parent = targetPath[targetPath.length - 1];
-          renderBookmarks(parent?.children || [], targetPath);
+      const mainAction = row.querySelector('.search-result-main');
+      const actionWrap = row.querySelector('.search-result-actions');
+
+      mainAction.addEventListener('click', () => {
+        if (item.type === 'link') {
+          openBookmarkInNewTab(item);
+          closeSearchModal();
+          return;
         }
+        revealBookmarkPath(item);
         closeSearchModal();
       });
+
+      if (item.type === 'link' && actionWrap) {
+        const openBtn = document.createElement('button');
+        openBtn.type = 'button';
+        openBtn.className = 'icon-action-btn h-8 w-8';
+        openBtn.title = t('searchOpenLink');
+        openBtn.setAttribute('aria-label', t('searchOpenLink'));
+        openBtn.innerHTML = '<svg class="h-4 w-4" viewBox="0 0 24 24" fill="none" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.8" d="M9 5l7 7-7 7"></path></svg>';
+        openBtn.addEventListener('click', (event) => {
+          event.stopPropagation();
+          openBookmarkInNewTab(item);
+          closeSearchModal();
+        });
+
+        const pathBtn = document.createElement('button');
+        pathBtn.type = 'button';
+        pathBtn.className = 'icon-action-btn h-8 w-8';
+        pathBtn.title = t('searchLocatePath');
+        pathBtn.setAttribute('aria-label', t('searchLocatePath'));
+        pathBtn.innerHTML = '<svg class="h-4 w-4" viewBox="0 0 24 24" fill="none" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.8" d="M3 7a2 2 0 0 1 2-2h4l2 2h8a2 2 0 0 1 2 2v8a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V7Z"></path></svg>';
+        pathBtn.addEventListener('click', (event) => {
+          event.stopPropagation();
+          revealBookmarkPath(item, { highlightBookmark: true });
+          closeSearchModal();
+        });
+
+        actionWrap.append(openBtn, pathBtn);
+      }
 
       container.appendChild(row);
     });

--- a/js/i18n.js
+++ b/js/i18n.js
@@ -26,6 +26,8 @@ window.I18N_MESSAGES = {
     filterTagsButton: '按标签筛选',
     backToTop: '回到顶部',
     closeSidebar: '关闭侧边栏',
+    searchOpenLink: '新标签页打开',
+    searchLocatePath: '定位所在文件夹',
   },
   en: {
     clear: 'Clear',
@@ -54,5 +56,7 @@ window.I18N_MESSAGES = {
     filterTagsButton: 'Filter by tags',
     backToTop: 'Back to top',
     closeSidebar: 'Close sidebar',
+    searchOpenLink: 'Open in new tab',
+    searchLocatePath: 'Locate in folder',
   },
 };


### PR DESCRIPTION
### Motivation
- 在大屏与侧边栏切换时当前每行卡片数量固定导致空间浪费，需要根据可用宽度实时自适应列数以提升信息密度和视觉一致性。  
- 依赖单个图标源（如 Google S2）易产生加载错误和控制台报错，需要更稳健的 favicon 回退策略以提高图标命中率。  
- 搜索结果交互不符合常见预期，点击应快速打开链接且同时提供“定位所在路径”的显性操作以方便导航和高亮目标。  

### Description
- 新增自适应网格样式 `folder-grid-auto` 和 `bookmark-grid-auto`（在 `index.html` 中内联样式），使用 `repeat(auto-fill, minmax(...))` 让卡片根据容器宽度自动换列并加入 `bookmark-highlight` 高亮样式用于跳转后短时标注。  
- 用多候选 favicon 策略替换原有单一 `google.com/s2` 源，新增 `getIconCandidates` 并在卡片图标 `onerror` 中按顺序回退到站点 `favicon.ico`、`apple-touch-icon.png`、DuckDuckGo、icon.horse 到本地 `assets/default-icon.svg`（修改点在 `index.html` 中的图标生成/回退逻辑）。  
- 为每个书签在 `flattenData` 中生成稳定的 `__id` 并通过 `createCard(..., bookmarkId)` 将 `data-bookmark-id` 附到渲染卡片上，以便后续定位与高亮（变更位于 `index.html`）。  
- 增强搜索面板交互：将 `renderSearchResultsPanel`（`js/components/search-ui.js`）改为在行内显示主动作与悬停动作区，单击主动作时对链接项默认调用 `openBookmarkInNewTab`，同时在悬停时显示两个按钮 —— 右箭头用于在新标签页打开，文件夹图标用于调用 `revealBookmarkPath(item, { highlightBookmark: true })`，后者会跳转至所在文件夹并平滑滚动与高亮目标 3 秒。  
- 增加国际化键 `searchOpenLink` 和 `searchLocatePath`（中/英文）到 `js/i18n.js` 以支持按钮文案。  

### Testing
- 运行构建验证命令 `npm run build` 成功，Tailwind 重新生成 CSS 并且 `generate-env` 步骤输出正常。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dde5c45608832c967ce687792d787b)